### PR TITLE
docs: add documentation for binary cache status and NixHub features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,13 @@ Only **2 MCP tools** are exposed (consolidated from 17 in v1.0):
 - `nix_versions` - Package version history from NixHub.io.
 
 ### Data Sources
+
 - NixOS packages/options: Elasticsearch API at search.nixos.org
 - Home Manager options: HTML parsing from official docs
 - nix-darwin options: HTML parsing from official docs
 - Package versions: NixHub.io API (search.devbox.sh)
+- Package metadata: NixHub.io API for license, homepage, store paths
+- Binary cache status: cache.nixos.org narinfo queries
 - Flakes: search.nixos.org flake index
 - Local flake inputs: Direct access to /nix/store via `nix flake archive`
 
@@ -130,10 +133,12 @@ pytest tests/ -k "nixos" -v
 1. **Channel Resolution**: The server dynamically discovers available NixOS channels on startup. "stable" always maps to the current stable release.
 2. **Error Handling**: All tools return helpful plain text error messages. API failures gracefully degrade.
 3. **No Caching**: Version 1.0+ removed all caching for simplicity. All queries hit live APIs.
-4. **Async Everything**: Version 1.0.1 migrated to FastMCP 2.x. All tools are async functions.
+4. **Async Everything**: Version 1.0.1 migrated to FastMCP 2.x. All tools are async functions. All blocking HTTP calls and file I/O are wrapped in `asyncio.to_thread()` to prevent blocking the event loop.
 5. **Plain Text Output**: All responses are formatted as human-readable plain text. Never return raw JSON or XML to users.
 6. **Environment Variables**: `ELASTICSEARCH_URL` overrides the NixOS search backend for local testing.
 7. **Flake Inputs**: The `flake-inputs` action requires nix to be installed locally. It uses `nix flake archive --json` to discover inputs and their store paths, with security validation to ensure paths stay within `/nix/store/`.
+8. **Binary Cache Status**: The `cache` action queries cache.nixos.org to check if packages have pre-built binaries. It uses NixHub to resolve package versions to store paths, then checks narinfo availability.
+9. **NixHub Source**: The `nixhub` source provides rich package metadata including license, homepage, programs, and store paths via the search.devbox.sh API.
 
 ## Commit, PR, & Release Guidelines
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ An MCP server providing accurate, real-time information about:
 - **NixOS Wiki** - Community documentation and guides from [wiki.nixos.org](https://wiki.nixos.org)
 - **nix.dev** - Official Nix tutorials and guides from [nix.dev](https://nix.dev)
 - **Package versions** - Historical versions with commit hashes via [NixHub.io](https://www.nixhub.io)
+- **Binary cache status** - Check if packages are cached on cache.nixos.org with download sizes
 - **Local flake inputs** - Explore your pinned flake dependencies directly from the Nix store (requires Nix)
 
 ## The Tools
@@ -97,6 +98,7 @@ nix(action, query, source, type, channel, limit)
 | `options` | Browse Home Manager/Darwin options by prefix |
 | `channels` | List available NixOS channels |
 | `flake-inputs` | Explore local flake inputs from Nix store |
+| `cache` | Check binary cache status for packages |
 
 | Source | What it queries |
 |--------|----------------|
@@ -109,6 +111,7 @@ nix(action, query, source, type, channel, limit)
 | `noogle` | Nix function signatures and docs (noogle.dev) |
 | `wiki` | NixOS Wiki articles (wiki.nixos.org) |
 | `nix-dev` | Official Nix documentation (nix.dev) |
+| `nixhub` | Package metadata and store paths (nixhub.io) |
 
 **Examples:**
 
@@ -155,6 +158,21 @@ nix(action="info", query="Flakes", source="wiki")
 # Search nix.dev documentation
 nix(action="search", query="packaging tutorial", source="nix-dev")
 
+# Search NixHub for package metadata
+nix(action="search", query="nodejs", source="nixhub")
+
+# Get detailed package info from NixHub (license, homepage, store paths)
+nix(action="info", query="python", source="nixhub")
+
+# Check binary cache status
+nix(action="cache", query="hello")
+
+# Check cache for specific version
+nix(action="cache", query="python", version="3.12.0")
+
+# Check cache for specific system
+nix(action="cache", query="firefox", system="x86_64-linux")
+
 # Get stats
 nix(action="stats", source="nixos", channel="stable")
 
@@ -170,16 +188,20 @@ nix(action="flake-inputs", type="read", query="nixpkgs:flake.nix")
 
 ### `nix_versions` - Package Version History
 
-Find historical versions with nixpkgs commit hashes:
+Find historical versions with nixpkgs commit hashes. Output includes:
+- Package metadata (license, homepage, programs) when available
+- Platform availability per version (Linux/macOS)
+- Nixpkgs commit hash for reproducible builds
+- Attribute path for Nix expressions
 
-```
+```python
 nix_versions(package, version, limit)
 ```
 
 **Examples:**
 
 ```python
-# List recent versions
+# List recent versions with metadata
 nix_versions(package="python", limit=5)
 
 # Find specific version

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
           <h1 className="text-4xl md:text-6xl font-bold mb-6">MCP-NixOS</h1>
           <div className="mb-4">
             <span className="inline-block bg-nix-secondary text-white px-4 py-2 rounded-full text-sm font-semibold">
-              🎉 v2.1.1 - Pure Nix Flake
+              🎉 v2.2.0 - Binary Cache & NixHub
             </span>
           </div>
           <div className="mb-8 max-w-3xl mx-auto">
@@ -128,6 +128,16 @@ export default function Home() {
               title="Version History"
               description="Package version tracking with nixpkgs commit hashes via NixHub.io integration."
               iconName="history"
+            />
+            <FeatureCard
+              title="Binary Cache Status"
+              description="Check if packages are cached on cache.nixos.org. See download sizes, compression, and availability per platform."
+              iconName="cloud-download"
+            />
+            <FeatureCard
+              title="NixHub Metadata"
+              description="Rich package metadata including license, homepage, programs, and Nix store paths from NixHub.io."
+              iconName="database"
             />
             <FeatureCard
               title="Local Flake Inputs"

--- a/website/app/usage/page.tsx
+++ b/website/app/usage/page.tsx
@@ -135,6 +135,51 @@ environment.systemPackages = [ pkgs.mcp-nixos ];`}
             </div>
           </div>
 
+          {/* New in v2.2.0 */}
+            <div className="bg-white rounded-lg shadow-md border-l-4 border-green-500 p-6 mt-8">
+              <h2 className="text-2xl font-bold text-nix-dark mb-4">
+                New in v2.2.0: Binary Cache & NixHub
+              </h2>
+              <p className="text-gray-700 mb-4">
+                Two powerful new features to help you understand what&apos;s actually happening with your packages.
+              </p>
+
+              <h3 className="text-lg font-semibold text-nix-dark mt-4 mb-2">Binary Cache Status</h3>
+              <p className="text-gray-700 mb-2">
+                Check if a package is cached on cache.nixos.org before building:
+              </p>
+              <CodeBlock
+                code={`# Check if hello is cached
+nix(action="cache", query="hello")
+
+# Check specific version
+nix(action="cache", query="python", version="3.12.0")
+
+# Check for specific system
+nix(action="cache", query="firefox", system="x86_64-linux")`}
+                language="python"
+              />
+              <p className="text-sm text-gray-600 mt-2">
+                Shows download size, unpacked size, compression method, and availability per platform.
+              </p>
+
+              <h3 className="text-lg font-semibold text-nix-dark mt-6 mb-2">NixHub Package Metadata</h3>
+              <p className="text-gray-700 mb-2">
+                Get rich package information from NixHub.io:
+              </p>
+              <CodeBlock
+                code={`# Search packages with metadata
+nix(action="search", source="nixhub", query="nodejs")
+
+# Get detailed info (license, homepage, store paths)
+nix(action="info", source="nixhub", query="python")`}
+                language="python"
+              />
+              <p className="text-sm text-gray-600 mt-2">
+                Includes license, homepage, programs provided, flake reference, and Nix store paths.
+              </p>
+            </div>
+
           <div className="bg-nix-light bg-opacity-30 p-6 rounded-lg mt-12">
             <h2 className="text-2xl font-bold text-nix-dark mb-4">What Happens Next?</h2>
             <p className="text-gray-700 mb-4">
@@ -145,6 +190,7 @@ environment.systemPackages = [ pkgs.mcp-nixos ];`}
               <li>You get actual, real-time information about 130K+ packages</li>
               <li>Configuration options that actually exist (shocking, we know)</li>
               <li>Version history that helps you find that one specific Ruby version from 2019</li>
+              <li>Binary cache status so you know if you&apos;ll be waiting 3 hours to build Firefox</li>
             </ul>
             <p className="text-gray-700 mt-4 italic">
               That&apos;s it. No complex setup. No 47-step installation guide. No sacrificing a USB stick to the Nix gods.

--- a/website/components/FeatureCard.tsx
+++ b/website/components/FeatureCard.tsx
@@ -75,6 +75,18 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ title, description, iconName 
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
           </svg>
         );
+      case 'cloud-download':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-nix-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
+          </svg>
+        );
+      case 'database':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-nix-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+          </svg>
+        );
       default:
         return (
           <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-nix-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary

This PR updates all documentation to cover the new v2.2.0 features: binary cache status checking and NixHub as a data source.

### Documentation Updates

**README.md:**
- Added `cache` action to the action table
- Added `nixhub` source to the source table  
- Added examples for cache status queries and NixHub search/info
- Documented enhanced `nix_versions` output (license, platforms, nixpkgs commit)
- Added binary cache status to the feature list at the top

**CLAUDE.md/AGENTS.md:**
- Added NixHub and binary cache to data sources section
- Updated async implementation note to mention `asyncio.to_thread` usage
- Added implementation notes for cache and nixhub features

**Website (page.tsx):**
- Updated version badge from v2.1.1 to v2.2.0
- Added feature cards for "Binary Cache Status" and "NixHub Metadata"
- Added `cloud-download` and `database` icons to FeatureCard component

**Website (usage/page.tsx):**
- Added new "New in v2.2.0" section with examples
- Added code examples for cache status and NixHub queries
- Updated "What Happens Next" list to mention binary cache

## Test Plan

- [x] Website builds successfully (`npm run build`)
- [x] Python linting passes (`ruff check`)
- [ ] Visual review of website changes
- [ ] Review README rendering on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Binary cache status: Check if packages are pre-cached on cache.nixos.org with download size information
  * NixHub metadata source: Access enhanced package information including license and homepage details
  * New `cache` action: Query package cache status with version and system-specific filtering

* **Documentation**
  * Added examples demonstrating new cache and NixHub capabilities
  * Updated interface to highlight v2.2.0 features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->