### PR TITLE
fix: use list types for pytest ini_options in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-python_files = "test_*.py"
-python_classes = "Test*"
-python_functions = "test_*"
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
 addopts = [
     "--verbose",
     "--cov=mcp_nixos",


### PR DESCRIPTION
Pytest 9 (In Unstable nixos) https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05 fails to build this package due to toml changes.

This just updates the pyproject.toml to the correct syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pytest configuration formatting in project settings for consistency.
  
* **Tests**
  * Enhanced test coverage reporting with additional output format to display missing coverage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->