### PR TITLE
fix: report package version in MCP serverInfo response

### DIFF
--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -17,6 +17,8 @@ from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
+from . import __version__
+
 # Import from our modules
 from .caches import (
     ChannelCache,
@@ -132,7 +134,7 @@ from .utils import (
 )
 
 # Create MCP server instance
-mcp = FastMCP("mcp-nixos")
+mcp = FastMCP("mcp-nixos", version=__version__)
 
 
 _TRUE_TOKENS = {"1", "true", "yes", "y", "on"}


### PR DESCRIPTION
## Summary

- Pass `__version__` to the `FastMCP` constructor so MCP clients receive the actual mcp-nixos package version (e.g. `2.2.0`) in the `serverInfo.version` field instead of the MCP SDK version (`1.25.0`).

Closes #101

## Test plan

- [x] `echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | mcp-nixos` returns `"version":"2.2.0"` in `serverInfo`
- [x] All 288 tests pass
- [x] Lint, format, and typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server initialization to properly track and report version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->