### PR TITLE
fix: improve tool descriptions for local agents (#123, #125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ TODO.md
 *.log
 *.DS_Store
 
+# Pi coding agent extensions (editor-only deps; Pi resolves at runtime)
+/.pi/node_modules/
+/.pi/package-lock.json
+
 # Website (Next.js)
 /website/node_modules/
 /website/.next/

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -46,12 +46,21 @@ interface CommandResult {
 	stderr: string;
 }
 
+class CancelledError extends Error {
+	constructor() {
+		super("Cancelled");
+		this.name = "CancelledError";
+	}
+}
+
 async function runCommand(
 	command: string,
 	args: string[],
 	env: NodeJS.ProcessEnv,
 	signal?: AbortSignal,
 ): Promise<CommandResult> {
+	if (signal?.aborted) throw new CancelledError();
+
 	return new Promise((resolvePromise, reject) => {
 		const child = spawn(command, args, {
 			cwd: projectRoot,
@@ -69,26 +78,20 @@ async function runCommand(
 			stderr += String(chunk);
 		});
 
-		child.on("error", reject);
+		const onAbort = () => {
+			child.kill("SIGTERM");
+			reject(new CancelledError());
+		};
+		if (signal) signal.addEventListener("abort", onAbort, { once: true });
+
+		child.on("error", (err) => {
+			signal?.removeEventListener("abort", onAbort);
+			reject(err);
+		});
 		child.on("close", (code) => {
+			signal?.removeEventListener("abort", onAbort);
 			resolvePromise({ code, stdout, stderr });
 		});
-
-		if (signal) {
-			if (signal.aborted) {
-				child.kill("SIGTERM");
-				reject(new Error("Cancelled"));
-				return;
-			}
-			signal.addEventListener(
-				"abort",
-				() => {
-					child.kill("SIGTERM");
-					reject(new Error("Cancelled"));
-				},
-				{ once: true },
-			);
-		}
 	});
 }
 
@@ -122,6 +125,10 @@ async function runNixosTool(tool: "nix" | "nix_versions", args: unknown, signal?
 			}
 			errors.push(`${candidate.command} exited with ${result.code}: ${(result.stderr || result.stdout).trim()}`);
 		} catch (error) {
+			// Cancellation stops retries — don't spawn more Python processes after abort.
+			if (error instanceof CancelledError || signal?.aborted) {
+				throw error instanceof CancelledError ? error : new CancelledError();
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			errors.push(`${candidate.command}: ${message}`);
 		}
@@ -153,7 +160,10 @@ const nixToolParams = Type.Object({
 	source: Type.Optional(
 		Type.String({
 			description:
-				"Data source. One of: nixos (default), home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub.",
+				"Data source for search/info/stats/browse/cache. One of: nixos (default), " +
+				"home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. " +
+				"For action=flake-inputs, this may instead be a path to a flake directory; " +
+				"omit/default to use the current project.",
 		}),
 	),
 	type: Type.Optional(

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -17,14 +17,20 @@ import sys
 from mcp_nixos.server import nix, nix_versions
 
 
+def _callable(tool):
+    # FastMCP 2.x wraps @mcp.tool() functions as FunctionTool (not directly callable);
+    # FastMCP 3.x keeps them as plain async functions. Support both.
+    return getattr(tool, "fn", tool)
+
+
 async def main() -> None:
     tool = os.environ["PI_NIXOS_TOOL"]
     args = json.loads(os.environ["PI_NIXOS_ARGS"])
 
     if tool == "nix":
-        result = await nix(**args)
+        result = await _callable(nix)(**args)
     elif tool == "nix_versions":
-        result = await nix_versions(**args)
+        result = await _callable(nix_versions)(**args)
     else:
         raise ValueError(f"Unknown tool: {tool}")
 

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -1,0 +1,278 @@
+import { type Static, Type } from "@mariozechner/pi-ai";
+import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const extensionDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(extensionDir, "../..");
+
+const PYTHON_SCRIPT = String.raw`
+import asyncio
+import json
+import os
+import sys
+
+from mcp_nixos.server import nix, nix_versions
+
+
+async def main() -> None:
+    tool = os.environ["PI_NIXOS_TOOL"]
+    args = json.loads(os.environ["PI_NIXOS_ARGS"])
+
+    if tool == "nix":
+        result = await nix(**args)
+    elif tool == "nix_versions":
+        result = await nix_versions(**args)
+    else:
+        raise ValueError(f"Unknown tool: {tool}")
+
+    sys.stdout.write(result)
+
+
+asyncio.run(main())
+`;
+
+interface CommandResult {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	signal?: AbortSignal,
+): Promise<CommandResult> {
+	return new Promise((resolvePromise, reject) => {
+		const child = spawn(command, args, {
+			cwd: projectRoot,
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+
+		child.stdout.on("data", (chunk) => {
+			stdout += String(chunk);
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += String(chunk);
+		});
+
+		child.on("error", reject);
+		child.on("close", (code) => {
+			resolvePromise({ code, stdout, stderr });
+		});
+
+		if (signal) {
+			if (signal.aborted) {
+				child.kill("SIGTERM");
+				reject(new Error("Cancelled"));
+				return;
+			}
+			signal.addEventListener(
+				"abort",
+				() => {
+					child.kill("SIGTERM");
+					reject(new Error("Cancelled"));
+				},
+				{ once: true },
+			);
+		}
+	});
+}
+
+async function runNixosTool(tool: "nix" | "nix_versions", args: unknown, signal?: AbortSignal): Promise<string> {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		PI_NIXOS_TOOL: tool,
+		PI_NIXOS_ARGS: JSON.stringify(args),
+	};
+	delete env.PYTHONPATH;
+	delete env.PYTHONHOME;
+	delete env.__PYVENV_LAUNCHER__;
+
+	const candidates: Array<{ command: string; args: string[] }> = [];
+	const venvPython = resolve(projectRoot, ".venv/bin/python");
+	if (existsSync(venvPython)) {
+		candidates.push({ command: venvPython, args: ["-c", PYTHON_SCRIPT] });
+	}
+	candidates.push(
+		{ command: "uv", args: ["run", "python", "-c", PYTHON_SCRIPT] },
+		{ command: "python3", args: ["-c", PYTHON_SCRIPT] },
+		{ command: "python", args: ["-c", PYTHON_SCRIPT] },
+	);
+
+	const errors: string[] = [];
+	for (const candidate of candidates) {
+		try {
+			const result = await runCommand(candidate.command, candidate.args, env, signal);
+			if (result.code === 0) {
+				return result.stdout.trimEnd();
+			}
+			errors.push(`${candidate.command} exited with ${result.code}: ${(result.stderr || result.stdout).trim()}`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			errors.push(`${candidate.command}: ${message}`);
+		}
+	}
+
+	throw new Error(
+		[
+			"Failed to run mcp-nixos from pi.",
+			"Tried .venv/bin/python, uv, python3, and python in the repository root.",
+			...errors,
+		].join("\n"),
+	);
+}
+
+const nixToolParams = Type.Object({
+	action: Type.String({
+		description:
+			"One of: search, info, stats, browse, channels, flake-inputs, cache. " +
+			"search = keyword lookup; info = details for a specific name; " +
+			"browse = walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only).",
+	}),
+	query: Type.Optional(
+		Type.String({
+			description:
+				"Search term for 'search', exact name for 'info', prefix path for 'browse'. " +
+				"For flake-inputs: input_name or input:path. Omit for 'stats'/'channels'.",
+		}),
+	),
+	source: Type.Optional(
+		Type.String({
+			description:
+				"Data source. One of: nixos (default), home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub.",
+		}),
+	),
+	type: Type.Optional(
+		Type.String({
+			description:
+				"Sub-type of query. For source=nixos with action=search: packages, options, programs. " +
+				"For source=nixos with action=info: package or option. For flake-inputs: list, ls, or read. " +
+				"Ignored by most other sources.",
+		}),
+	),
+	channel: Type.Optional(
+		Type.String({ description: "NixOS channel: unstable (default), stable, or a release like 25.05." }),
+	),
+	limit: Type.Optional(
+		Type.Integer({ description: "Max results. 1-100 (or 1-2000 for flake-inputs read). Default 20." }),
+	),
+	version: Type.Optional(
+		Type.String({ description: "Only used by action=cache. Package version (default: latest)." }),
+	),
+	system: Type.Optional(
+		Type.String({
+			description: "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all.",
+		}),
+	),
+});
+
+type NixToolParams = Static<typeof nixToolParams>;
+
+const nixToolDescription = [
+	"Query live NixOS data (packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, Noogle, NixHub, binary cache).",
+	"",
+	"Examples (copy the JSON shape exactly):",
+	'  Search NixOS packages:    {"action": "search", "query": "firefox"}',
+	'  Search NixOS options:     {"action": "search", "query": "nginx", "type": "options"}',
+	'  Get a package:            {"action": "info", "query": "firefox"}',
+	'  Get an option:            {"action": "info", "query": "services.nginx.enable", "type": "option"}',
+	'  Search Home Manager:      {"action": "search", "query": "git", "source": "home-manager"}',
+	'  Browse HM option tree:    {"action": "browse", "query": "programs", "source": "home-manager"}',
+	'  Search the wiki:          {"action": "search", "query": "zfs", "source": "wiki"}',
+	'  List channels:            {"action": "channels"}',
+	'  Check binary cache:       {"action": "cache", "query": "firefox"}',
+	"",
+	"Notes:",
+	"  - To search NixOS options, use action=search with type=options. Do NOT use action=browse for source=nixos.",
+	"  - action=browse walks a pre-indexed option tree and only supports home-manager, darwin, nixvim, or noogle.",
+	"  - Omit optional parameters; don't pass empty strings.",
+	"  - For package version history use the separate nix_versions tool.",
+].join("\n");
+
+const nixTool = defineTool({
+	name: "nix",
+	label: "NixOS",
+	description: nixToolDescription,
+	promptSnippet:
+		"Prefer the nix tool over web search for NixOS packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, Noogle, flake inputs, and binary cache status.",
+	promptGuidelines: [
+		"Prefer the nix tool over web search for NixOS-related package, option, flake, wiki, nix.dev, and cache questions.",
+		'To search NixOS options: {"action": "search", "query": "<keyword>", "type": "options"}.',
+		'To inspect a NixOS option: {"action": "info", "query": "<option.path>", "type": "option"}.',
+		"action=browse is for walking option prefixes in home-manager, darwin, nixvim, or noogle only — never with source=nixos.",
+	],
+	parameters: nixToolParams,
+	async execute(_toolCallId: string, params: NixToolParams, signal: AbortSignal | undefined) {
+		// Legacy alias: older model sessions may still emit action=options.
+		// server.py also normalizes this, but translating here keeps details.args honest.
+		const action = params.action === "options" ? "browse" : params.action;
+
+		const normalized = {
+			action,
+			query: params.query ?? "",
+			source: params.source ?? "nixos",
+			type: params.type ?? "packages",
+			channel: params.channel ?? "unstable",
+			limit: params.limit ?? 20,
+			version: params.version ?? "latest",
+			system: params.system ?? "",
+		};
+
+		const text = await runNixosTool("nix", normalized, signal);
+		return {
+			content: [{ type: "text", text }],
+			details: { tool: "nix", args: normalized },
+		};
+	},
+});
+
+const nixVersionsParams = Type.Object({
+	package: Type.String({ description: "Package name, e.g. git or firefox." }),
+	version: Type.Optional(Type.String({ description: "Optional exact version to find." })),
+	limit: Type.Optional(Type.Integer({ description: "How many recent versions to return (1-50, default 10)." })),
+});
+
+type NixVersionsParams = Static<typeof nixVersionsParams>;
+
+const nixVersionsTool = defineTool({
+	name: "nix_versions",
+	label: "NixOS Versions",
+	description: [
+		"Get a Nix package's version history from NixHub.io (commit hashes, license, homepage, programs).",
+		"",
+		"Examples:",
+		'  Recent versions:      {"package": "git"}',
+		'  Find exact version:   {"package": "git", "version": "2.42.0"}',
+	].join("\n"),
+	promptSnippet: "Look up historical versions for a Nix package, including commit hashes and metadata.",
+	promptGuidelines: [
+		"Use nix_versions when the user wants version history or wants to pin a specific historical package version.",
+	],
+	parameters: nixVersionsParams,
+	async execute(_toolCallId: string, params: NixVersionsParams, signal: AbortSignal | undefined) {
+		const normalized = {
+			package: params.package,
+			version: params.version ?? "",
+			limit: params.limit ?? 10,
+		};
+
+		const text = await runNixosTool("nix_versions", normalized, signal);
+		return {
+			content: [{ type: "text", text }],
+			details: { tool: "nix_versions", args: normalized },
+		};
+	},
+});
+
+export default function mcpNixosExtension(pi: ExtensionAPI) {
+	pi.registerTool(nixTool);
+	pi.registerTool(nixVersionsTool);
+}

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -159,7 +159,7 @@ const nixToolParams = Type.Object({
 	type: Type.Optional(
 		Type.String({
 			description:
-				"Sub-type of query. For source=nixos with action=search: packages, options, programs. " +
+				"Sub-type of query. For source=nixos with action=search: packages, options, programs, flakes. " +
 				"For source=nixos with action=info: package or option. For flake-inputs: list, ls, or read. " +
 				"Ignored by most other sources.",
 		}),

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -159,9 +159,9 @@ const nixToolParams = Type.Object({
 	type: Type.Optional(
 		Type.String({
 			description:
-				"Sub-type of query. For source=nixos with action=search: packages, options, programs, flakes. " +
-				"For source=nixos with action=info: package or option. For flake-inputs: list, ls, or read. " +
-				"Ignored by most other sources.",
+				"Sub-type of query. For source=nixos with action=search, one of: " +
+				"packages, options, programs, flakes. For source=nixos with action=info, one of: " +
+				"package, option. For flake-inputs, one of: list, ls, read. Ignored by most other sources.",
 		}),
 	),
 	channel: Type.Optional(
@@ -221,16 +221,19 @@ const nixTool = defineTool({
 		// server.py also normalizes this, but translating here keeps details.args honest.
 		const action = params.action === "options" ? "browse" : params.action;
 
-		const normalized = {
-			action,
-			query: params.query ?? "",
-			source: params.source ?? "nixos",
-			type: params.type ?? "packages",
-			channel: params.channel ?? "unstable",
-			limit: params.limit ?? 20,
-			version: params.version ?? "latest",
-			system: params.system ?? "",
-		};
+		// Only forward keys the caller actually set. Passing empty-string defaults would
+		// (a) echo noisy args back in details.args, contradicting the "omit optional
+		// parameters" guidance in the tool description, and (b) train small models to
+		// copy those empties into future calls. The Python server already supplies its
+		// own sensible defaults when a key is omitted.
+		const normalized: Record<string, string | number> = { action };
+		if (params.query !== undefined) normalized.query = params.query;
+		if (params.source !== undefined) normalized.source = params.source;
+		if (params.type !== undefined) normalized.type = params.type;
+		if (params.channel !== undefined) normalized.channel = params.channel;
+		if (params.limit !== undefined) normalized.limit = params.limit;
+		if (params.version !== undefined) normalized.version = params.version;
+		if (params.system !== undefined) normalized.system = params.system;
 
 		const text = await runNixosTool("nix", normalized, signal);
 		return {
@@ -264,11 +267,9 @@ const nixVersionsTool = defineTool({
 	],
 	parameters: nixVersionsParams,
 	async execute(_toolCallId: string, params: NixVersionsParams, signal: AbortSignal | undefined) {
-		const normalized = {
-			package: params.package,
-			version: params.version ?? "",
-			limit: params.limit ?? 10,
-		};
+		const normalized: Record<string, string | number> = { package: params.package };
+		if (params.version !== undefined) normalized.version = params.version;
+		if (params.limit !== undefined) normalized.limit = params.limit;
 
 		const text = await runNixosTool("nix_versions", normalized, signal);
 		return {

--- a/.pi/package.json
+++ b/.pi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mcp-nixos-pi-extensions",
+  "private": true,
+  "description": "Project-local pi-coding-agent extension that exposes mcp-nixos as native Pi tools. Install dev deps (npm install) only if you want editor type resolution; Pi itself resolves these from its own install at runtime.",
+  "type": "module",
+  "devDependencies": {
+    "@mariozechner/pi-ai": "^0.68.0",
+    "@mariozechner/pi-coding-agent": "^0.68.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/.pi/tsconfig.json
+++ b/.pi/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["extensions/**/*.ts"]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.14.10
     hooks:
     -   id: ruff
         args: ["--fix"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,32 @@ Stateless HTTP (disables per-client session state):
 MCP_NIXOS_TRANSPORT=http MCP_NIXOS_STATELESS_HTTP=1 mcp-nixos
 ```
 
+### Option 5: Pi Coding Agent
+
+[Pi](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) does not speak MCP natively. Two supported paths:
+
+**A. pi-mcp-adapter (recommended — speaks MCP, single source of truth):**
+
+```bash
+pi install npm:pi-mcp-adapter
+```
+
+Then add to `~/.pi/agent/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nixos": {
+      "command": "uvx",
+      "args": ["mcp-nixos"],
+      "lifecycle": "lazy"
+    }
+  }
+}
+```
+
+**B. Project-local extension (clone + run):** this repo ships `.pi/extensions/mcp-nixos.ts`, auto-loaded when you run `pi` in the cloned repo. Optional: `cd .pi && npm install` for editor type resolution. Pi runs it either way.
+
 ## What Is This?
 
 An MCP server providing accurate, real-time information about:

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -178,7 +178,7 @@ async def nix(
     ] = "nixos",
     type: Annotated[
         str,
-        "Sub-type of query. For source=nixos with action=search: packages|options|programs. "
+        "Sub-type of query. For source=nixos with action=search: packages|options|programs|flakes. "
         "For source=nixos with action=info: package|option. For flake-inputs: list|ls|read. "
         "Ignored by most other sources.",
     ] = "packages",
@@ -187,7 +187,7 @@ async def nix(
     version: Annotated[str, "Only used by action=cache. Package version (default: latest)."] = "latest",
     system: Annotated[str, "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all."] = "",
 ) -> str:
-    """Query NixOS, Home Manager, Darwin, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
+    """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
 
     Examples (the JSON shape matters — copy exactly):
       Search NixOS packages:    {"action": "search", "query": "firefox"}
@@ -283,7 +283,7 @@ async def nix(
         else:
             return error(
                 f"Unknown source: {source!r}. For action=info, must be one of: "
-                "nixos, home-manager, darwin, flakehub, nixvim, wiki, noogle, nixhub."
+                "nixos, home-manager, darwin, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
             )
 
     elif action == "stats":

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -160,16 +160,53 @@ def env_bool(name: str, default: bool = False) -> bool:
 
 @mcp.tool()
 async def nix(
-    action: Annotated[str, "search|info|stats|options|channels|flake-inputs|cache"],
-    query: Annotated[str, "Search term, name, or prefix. For flake-inputs: input_name or input:path"] = "",
-    source: Annotated[str, "nixos|home-manager|darwin|flakes|flakehub|nixvim|wiki|nix-dev|noogle|nixhub"] = "nixos",
-    type: Annotated[str, "packages|options|programs|list|ls|read"] = "packages",
-    channel: Annotated[str, "unstable|stable|25.05"] = "unstable",
-    limit: Annotated[int, "1-100 (or 1-2000 for flake-inputs read)"] = 20,
-    version: Annotated[str, "Version for cache action (default: latest)"] = "latest",
-    system: Annotated[str, "System for cache action (e.g., x86_64-linux). Empty for all."] = "",
+    action: Annotated[
+        str,
+        "One of: search, info, stats, browse, channels, flake-inputs, cache. "
+        "Use 'search' for keyword lookup, 'info' for details about a specific name, "
+        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only).",
+    ],
+    query: Annotated[
+        str,
+        "Search term for 'search', exact name for 'info', prefix path for 'browse'. "
+        "For flake-inputs: input_name or input:path. Leave empty for 'stats'/'channels'.",
+    ] = "",
+    source: Annotated[
+        str,
+        "Data source. One of: nixos (default), home-manager, darwin, flakes, flakehub, "
+        "nixvim, wiki, nix-dev, noogle, nixhub.",
+    ] = "nixos",
+    type: Annotated[
+        str,
+        "Sub-type of query. For source=nixos with action=search: packages|options|programs. "
+        "For source=nixos with action=info: package|option. For flake-inputs: list|ls|read. "
+        "Ignored by most other sources.",
+    ] = "packages",
+    channel: Annotated[str, "NixOS channel: unstable (default), stable, or a release like 25.05."] = "unstable",
+    limit: Annotated[int, "Max results. 1-100 (or 1-2000 for flake-inputs read)."] = 20,
+    version: Annotated[str, "Only used by action=cache. Package version (default: latest)."] = "latest",
+    system: Annotated[str, "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all."] = "",
 ) -> str:
-    """Query NixOS, Home Manager, Darwin, flakes, FlakeHub, Nixvim, Wiki, nix.dev, Noogle, NixHub, or flake inputs."""
+    """Query NixOS, Home Manager, Darwin, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
+
+    Examples (the JSON shape matters — copy exactly):
+      Search NixOS packages:    {"action": "search", "query": "firefox"}
+      Search NixOS options:     {"action": "search", "query": "nginx", "type": "options"}
+      Get a package's details:  {"action": "info", "query": "firefox"}
+      Get an option's details:  {"action": "info", "query": "services.nginx.enable", "type": "option"}
+      Search Home Manager:      {"action": "search", "query": "git", "source": "home-manager"}
+      Browse HM option tree:    {"action": "browse", "query": "programs", "source": "home-manager"}
+      Search the NixOS wiki:    {"action": "search", "query": "zfs", "source": "wiki"}
+      List channels:            {"action": "channels"}
+      Check binary cache:       {"action": "cache", "query": "firefox"}
+
+    Notes:
+      - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
+        for source=nixos — browse is for walking a pre-indexed option tree and only works with
+        home-manager, darwin, nixvim, or noogle.
+      - Omit parameters you don't need; do not pass empty strings for optional args.
+      - For package version history use the separate `nix_versions` tool.
+    """
     # Limit validation: flake-inputs read allows up to 2000, others limited to 100
     if action == "flake-inputs" and type == "read":
         if not 1 <= limit <= MAX_LINE_LIMIT:
@@ -177,12 +214,20 @@ async def nix(
     elif not 1 <= limit <= 100:
         return error("Limit must be 1-100")
 
+    # Accept `browse` as canonical, keep `options` as a legacy alias.
+    # The action=options name was confusing small models (GitHub #125).
+    if action == "options":
+        action = "browse"
+
     if action == "search":
         if not query:
-            return error("Query required for search")
+            return error('Query required for search. Example: {"action": "search", "query": "firefox"}')
         if source == "nixos":
             if type not in ["packages", "options", "programs", "flakes"]:
-                return error("Type must be packages|options|programs|flakes")
+                return error(
+                    "For source=nixos, type must be one of: packages, options, programs, flakes. "
+                    'Example: {"action": "search", "query": "nginx", "type": "options"}'
+                )
             return await asyncio.to_thread(_search_nixos, query, type, limit, channel)
         elif source == "home-manager":
             return await asyncio.to_thread(_search_home_manager, query, limit)
@@ -203,14 +248,20 @@ async def nix(
         elif source == "nixhub":
             return await _search_nixhub(query, limit)
         else:
-            return error("Source must be nixos|home-manager|darwin|flakes|flakehub|nixvim|wiki|nix-dev|noogle|nixhub")
+            return error(
+                f"Unknown source: {source!r}. Must be one of: "
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
+            )
 
     elif action == "info":
         if not query:
-            return error("Name required for info")
+            return error('Name required for info. Example: {"action": "info", "query": "firefox"}')
         if source == "nixos":
             if type not in ["package", "packages", "option", "options"]:
-                return error("Type must be package|option")
+                return error(
+                    "For source=nixos, type must be 'package' or 'option'. "
+                    'Example: {"action": "info", "query": "services.nginx.enable", "type": "option"}'
+                )
             info_type = "package" if type in ["package", "packages"] else "option"
             return await asyncio.to_thread(_info_nixos, query, info_type, channel)
         elif source == "home-manager":
@@ -230,7 +281,10 @@ async def nix(
         elif source == "nixhub":
             return await _info_nixhub(query)
         else:
-            return error("Source must be nixos|home-manager|darwin|flakehub|nixvim|wiki|nix-dev|noogle|nixhub")
+            return error(
+                f"Unknown source: {source!r}. For action=info, must be one of: "
+                "nixos, home-manager, darwin, flakehub, nixvim, wiki, noogle, nixhub."
+            )
 
     elif action == "stats":
         if source == "nixos":
@@ -248,13 +302,26 @@ async def nix(
         elif source == "noogle":
             return await asyncio.to_thread(_stats_noogle)
         elif source in ["wiki", "nix-dev", "nixhub"]:
-            return error(f"Stats not available for {source}")
+            return error(f"Stats not available for source={source}.")
         else:
-            return error("Source must be nixos|home-manager|darwin|flakes|flakehub|nixvim|wiki|nix-dev|noogle|nixhub")
+            return error(
+                f"Unknown source: {source!r}. For action=stats, must be one of: "
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, noogle."
+            )
 
-    elif action == "options":
+    elif action == "browse":
+        if source == "nixos":
+            return error(
+                "action=browse is not for NixOS. To search NixOS options, use: "
+                '{"action": "search", "query": "<keyword>", "type": "options"}. '
+                "To get a specific option's details, use: "
+                '{"action": "info", "query": "<option.path>", "type": "option"}.'
+            )
         if source not in ["home-manager", "darwin", "nixvim", "noogle"]:
-            return error("Options browsing only for home-manager|darwin|nixvim|noogle")
+            return error(
+                "action=browse only supports source in: home-manager, darwin, nixvim, noogle. "
+                'Example: {"action": "browse", "query": "programs", "source": "home-manager"}'
+            )
         if source == "nixvim":
             return await asyncio.to_thread(_browse_nixvim_options, query)
         if source == "noogle":
@@ -301,7 +368,11 @@ async def nix(
         return await _check_binary_cache(query, version, system)
 
     else:
-        return error("Action must be search|info|stats|options|channels|flake-inputs|cache")
+        return error(
+            f"Unknown action: {action!r}. Must be one of: "
+            "search, info, stats, browse, channels, flake-inputs, cache. "
+            'Example: {"action": "search", "query": "firefox"}'
+        )
 
 
 @mcp.tool()

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -173,8 +173,10 @@ async def nix(
     ] = "",
     source: Annotated[
         str,
-        "Data source. One of: nixos (default), home-manager, darwin, flakes, flakehub, "
-        "nixvim, wiki, nix-dev, noogle, nixhub.",
+        "Data source for search/info/stats/browse/cache. One of: nixos (default), "
+        "home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. "
+        "For action=flake-inputs, this may instead be a path to a flake directory; "
+        "omit/default to use the current project.",
     ] = "nixos",
     type: Annotated[
         str,

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -178,9 +178,9 @@ async def nix(
     ] = "nixos",
     type: Annotated[
         str,
-        "Sub-type of query. For source=nixos with action=search: packages|options|programs|flakes. "
-        "For source=nixos with action=info: package|option. For flake-inputs: list|ls|read. "
-        "Ignored by most other sources.",
+        "Sub-type of query. For source=nixos with action=search, one of: "
+        "packages, options, programs, flakes. For source=nixos with action=info, one of: "
+        "package, option. For flake-inputs, one of: list, ls, read. Ignored by most other sources.",
     ] = "packages",
     channel: Annotated[str, "NixOS channel: unstable (default), stable, or a release like 25.05."] = "unstable",
     limit: Annotated[int, "Max results. 1-100 (or 1-2000 for flake-inputs read)."] = 20,
@@ -313,9 +313,9 @@ async def nix(
         if source == "nixos":
             return error(
                 "action=browse is not for NixOS. To search NixOS options, use: "
-                '{"action": "search", "query": "<keyword>", "type": "options"}. '
+                '{"action": "search", "query": "nginx", "type": "options"}. '
                 "To get a specific option's details, use: "
-                '{"action": "info", "query": "<option.path>", "type": "option"}.'
+                '{"action": "info", "query": "services.nginx.enable", "type": "option"}.'
             )
         if source not in ["home-manager", "darwin", "nixvim", "noogle"]:
             return error(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -30,7 +30,7 @@ class TestNixToolValidation:
     async def test_invalid_action(self):
         result = await nix_fn(action="invalid")
         assert "Error" in result
-        assert "search|info|stats|options|channels" in result
+        assert "search" in result and "browse" in result
 
     @pytest.mark.asyncio
     async def test_search_requires_query(self):
@@ -48,13 +48,30 @@ class TestNixToolValidation:
     async def test_invalid_source(self):
         result = await nix_fn(action="search", query="test", source="invalid")
         assert "Error" in result
-        assert "nixos|home-manager|darwin|flakes|flakehub|nixvim|wiki|nix-dev|noogle" in result
+        assert "nixos" in result and "home-manager" in result
 
     @pytest.mark.asyncio
-    async def test_options_only_for_hm_darwin_nixvim(self):
+    async def test_browse_nixos_redirects_to_search(self):
+        """action=browse with source=nixos should redirect to the correct search/info form (#125)."""
+        result = await nix_fn(action="browse", source="nixos")
+        assert "Error" in result
+        assert '"action": "search"' in result
+        assert '"type": "options"' in result
+
+    @pytest.mark.asyncio
+    async def test_options_alias_nixos_redirects_to_search(self):
+        """Legacy action=options alias should behave like browse and redirect for source=nixos."""
         result = await nix_fn(action="options", source="nixos")
         assert "Error" in result
-        assert "home-manager|darwin|nixvim|noogle" in result
+        assert '"action": "search"' in result
+        assert '"type": "options"' in result
+
+    @pytest.mark.asyncio
+    async def test_browse_only_for_hm_darwin_nixvim_noogle(self):
+        result = await nix_fn(action="browse", source="flakes")
+        assert "Error" in result
+        assert "home-manager" in result and "darwin" in result
+        assert "nixvim" in result and "noogle" in result
 
     @pytest.mark.asyncio
     async def test_limit_too_low(self):
@@ -282,9 +299,9 @@ class TestDottedPackageNameSearch:
 
         # There should be a clause matching package_attr_name
         attr_name_clauses = [c for c in should_clauses if "package_attr_name" in str(c)]
-        assert len(attr_name_clauses) > 0, (
-            "ES query should include package_attr_name in should clauses to support dotted package name searches"
-        )
+        assert (
+            len(attr_name_clauses) > 0
+        ), "ES query should include package_attr_name in should clauses to support dotted package name searches"
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")
@@ -340,9 +357,9 @@ class TestDottedPackageNameSearch:
             pname_value = pname_query["query"]
         else:
             pname_value = pname_query
-        assert pname_value == "matplotlib", (
-            f"package_pname should search for 'matplotlib' (last component), got '{pname_value}'"
-        )
+        assert (
+            pname_value == "matplotlib"
+        ), f"package_pname should search for 'matplotlib' (last component), got '{pname_value}'"
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -299,9 +299,9 @@ class TestDottedPackageNameSearch:
 
         # There should be a clause matching package_attr_name
         attr_name_clauses = [c for c in should_clauses if "package_attr_name" in str(c)]
-        assert (
-            len(attr_name_clauses) > 0
-        ), "ES query should include package_attr_name in should clauses to support dotted package name searches"
+        assert len(attr_name_clauses) > 0, (
+            "ES query should include package_attr_name in should clauses to support dotted package name searches"
+        )
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")
@@ -357,9 +357,9 @@ class TestDottedPackageNameSearch:
             pname_value = pname_query["query"]
         else:
             pname_value = pname_query
-        assert (
-            pname_value == "matplotlib"
-        ), f"package_pname should search for 'matplotlib' (last component), got '{pname_value}'"
+        assert pname_value == "matplotlib", (
+            f"package_pname should search for 'matplotlib' (last component), got '{pname_value}'"
+        )
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")


### PR DESCRIPTION
## Summary

Fixes two issues where small local models (qwen3.6, qwen3-coder) couldn't reliably map intent to the right `action`/`type` combo in the `nix` tool.

- **#125** — qwen3.6 kept picking `action=options` to search NixOS options, which rejected `source=nixos` with a generic error.
- **#123** — qwen3-coder looped for ~10 attempts trying to form valid JSON args.

## Root causes

1. **Name/behavior mismatch**: `action=options` sounded like "the options action" but actually meant "browse an option hierarchy by prefix" and didn't support `source=nixos` at all.
2. **Weak docstring**: the `nix` tool's description was one terse sentence. Frontier models filled the gap from priors; 30B-class models didn't.
3. **Noisy errors**: messages like `"Type must be packages|options|programs"` looked like pseudo-JSON and fed confusing pipes back into the next LLM attempt.

## Changes

- Rename action `options` → `browse` (silent alias kept for backward compat).
- `action=browse, source=nixos` now **redirects** — error body contains the exact correct JSON (`{"action": "search", ..., "type": "options"}`).
- Expand the `nix` tool docstring with 9 concrete JSON-shape examples + explicit search-vs-browse guidance.
- Tighten every `Annotated[...]` param description to say which action uses the parameter.
- Replace pipe-separated error messages with plain prose + example JSON.
- Resync `.pi/extensions/mcp-nixos.ts` with the server changes (Pi bypasses the Python `Annotated` descriptions, so the wrapper's own descriptions had to be updated too). Add `.pi/package.json` + `.pi/tsconfig.json` so the TS extension typechecks cleanly in-editor.
- Add README **Option 5: Pi Coding Agent** documenting both the `pi-mcp-adapter` path (recommended, speaks MCP) and the project-local `.pi/extensions` path.

## Test plan

- [x] `ruff format` + `ruff check` clean
- [x] `mypy mcp_nixos/` clean
- [x] `tsc --noEmit` clean for `.pi/extensions/`
- [x] 236 non-integration pytest tests pass, including two new tests for the redirect:
  - `test_browse_nixos_redirects_to_search`
  - `test_options_alias_nixos_redirects_to_search`
- [x] Verified on **ollama/qwen3.6:latest** (the model in #125) via `pi` on hal9000:
  - Prompt *"Find the NixOS option to enable nginx"* → first call: `{"action": "search", "query": "nginx enable", "type": "options"}`. Follow-up: `{"action": "info", "query": "services.nginx.enable", "type": "option"}`. No retries, correct answer.
  - Prompt *"Browse NixOS options starting with services.nginx"* (adversarial — the word "browse" biases toward `action=browse`) → model still correctly chose `{"action": "search", "query": "services.nginx", "type": "options"}`. The docstring note steered it away from `browse` for nixos.
- [ ] Still needs verification on qwen3-coder for #123 (JSON syntax loop). If the loop persists there, it likely points at Pi.dev client-side JSON parsing rather than tool descriptions, and #123 may need to be escalated to Pi upstream.

Closes #125 pending final verification; partial fix for #123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi Coding Agent integration with a local extension exposing Nix tooling, including a new nix_versions tool.
  * Introduced a canonical browse action for exploring option trees; legacy options remains supported (may redirect).

* **Documentation**
  * README updated with Pi integration and setup guidance.

* **Tests**
  * Tightened tests for action/source validation and redirect behavior.

* **Chores**
  * Updated ignore rules, project-local TypeScript config/package, and pre-commit tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->