### PR TITLE
feat: upgrade to fastmcp 3.x (closes #127)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-
     - `flake_inputs.py` - Local flake inputs via nix store.
 - `tests/` - Holds pytest unit and integration tests; markers live in `pytest.ini` and `tests/conftest.py`.
 - `website/` - The Next.js site; static assets live in `website/public/`.
+- `.pi/` - Pi Coding Agent extension that wraps the MCP tools as native Pi tools (Pi does not speak MCP). `extensions/mcp-nixos.ts` spawns a Python subprocess that imports `mcp_nixos.server` and calls the tool functions directly — not part of the MCP server runtime, only relevant when running `pi` in this repo.
 - `flake.nix` - Defines the Nix dev shell and build instructions.
 - `pyproject.toml` - Defines Python packaging and dependencies.
 - `dist/`, `htmlcov/`, and `result/` are generated artifacts; do not edit by hand.
@@ -37,7 +38,7 @@ MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-
 The project is a FastMCP 2.x server (async) with a modular structure (Python 3.11+). The server is organized into focused modules: `server.py` handles MCP tools and routing, `sources/` contains per-source implementations, `config.py` defines constants, `caches.py` manages cached data, and `utils.py` provides shared utilities.
 
 Only **2 MCP tools** are exposed (consolidated from 17 in v1.0):
-- `nix` - Unified query tool for search/info/stats/options/channels/flake-inputs across all sources.
+- `nix` - Unified query tool for search/info/stats/browse/channels/flake-inputs/cache across all sources. `options` is accepted as a silent alias for `browse` (legacy).
 - `nix_versions` - Package version history from NixHub.io.
 
 ### Data Sources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-
 
 ## Key Architecture
 
-The project is a FastMCP 2.x server (async) with a modular structure (Python 3.11+). The server is organized into focused modules: `server.py` handles MCP tools and routing, `sources/` contains per-source implementations, `config.py` defines constants, `caches.py` manages cached data, and `utils.py` provides shared utilities.
+The project is a FastMCP 3.x server (async) with a modular structure (Python 3.11+). The server is organized into focused modules: `server.py` handles MCP tools and routing, `sources/` contains per-source implementations, `config.py` defines constants, `caches.py` manages cached data, and `utils.py` provides shared utilities.
 
 Only **2 MCP tools** are exposed (consolidated from 17 in v1.0):
 - `nix` - Unified query tool for search/info/stats/browse/channels/flake-inputs/cache across all sources. `options` is accepted as a silent alias for `browse` (legacy).
@@ -169,7 +169,7 @@ pytest tests/ -k "nixos" -v
 1. **Channel Resolution**: The server dynamically discovers available NixOS channels on startup. "stable" always maps to the current stable release.
 2. **Error Handling**: All tools return helpful plain text error messages. API failures gracefully degrade.
 3. **No Caching**: Version 1.0+ removed all caching for simplicity. All queries hit live APIs.
-4. **Async Everything**: Version 1.0.1 migrated to FastMCP 2.x. All tools are async functions. All blocking HTTP calls and file I/O are wrapped in `asyncio.to_thread()` to prevent blocking the event loop.
+4. **Async Everything**: Version 1.0.1 migrated to FastMCP (currently FastMCP 3.x; `fastmcp>=3.2.0` in `pyproject.toml`). All tools are async functions. All blocking HTTP calls and file I/O are wrapped in `asyncio.to_thread()` to prevent blocking the event loop.
 5. **Plain Text Output**: All responses are formatted as human-readable plain text. Never return raw JSON or XML to users.
 6. **Environment Variables**:
    - `ELASTICSEARCH_URL` overrides the NixOS search backend for local testing.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767640445,
-        "narHash": "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f0c42f8bc7151b8e7e5840fb3bd454ad850d8c5",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -90,10 +90,26 @@
             inherit system;
             overlays = [
               (final: prev: {
-                # fastmcp in nixpkgs has overly strict mcp version bounds
+                # Upgrade fastmcp to 3.2.4 ahead of nixpkgs.
+                # Mirrors nixpkgs PR #510339 (PrefectHQ/fastmcp v3.2.4). Can be removed
+                # once that PR merges and our flake input moves past it.
                 pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
                   (pyFinal: pyPrev: {
-                    fastmcp = pyPrev.fastmcp.overridePythonAttrs (_: {
+                    fastmcp = pyPrev.fastmcp.overridePythonAttrs (old: rec {
+                      version = "3.2.4";
+                      src = prev.fetchFromGitHub {
+                        owner = "PrefectHQ";
+                        repo = "fastmcp";
+                        tag = "v${version}";
+                        hash = "sha256-rJpxPvqAaa6/vXhG1+R9dI32cY/54e6I+F/zyBVoqBM=";
+                      };
+                      dependencies = (old.dependencies or [ ]) ++ [
+                        pyFinal.griffelib
+                        pyFinal.opentelemetry-api
+                        pyFinal.uncalled-for
+                        pyFinal.watchfiles
+                        pyFinal.pyyaml
+                      ];
                       dontCheckRuntimeDeps = true;
                       doCheck = false;
                     });

--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,42 @@
       ];
 
       flake = {
-        overlays.default = final: _: {
-          mcp-nixos = mkMcpNixos { pkgs = final; };
+        # Upgrade fastmcp to 3.2.4 ahead of nixpkgs.
+        # Mirrors nixpkgs PR #510339 (PrefectHQ/fastmcp v3.2.4). Can be removed
+        # once that PR merges and our flake input moves past it.
+        overlays.fastmcp3 = final: prev: {
+          pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+            (pyFinal: pyPrev: {
+              fastmcp = pyPrev.fastmcp.overridePythonAttrs (old: rec {
+                version = "3.2.4";
+                src = prev.fetchFromGitHub {
+                  owner = "PrefectHQ";
+                  repo = "fastmcp";
+                  tag = "v${version}";
+                  hash = "sha256-rJpxPvqAaa6/vXhG1+R9dI32cY/54e6I+F/zyBVoqBM=";
+                };
+                dependencies = (old.dependencies or [ ]) ++ [
+                  pyFinal.griffelib
+                  pyFinal.opentelemetry-api
+                  pyFinal.uncalled-for
+                  pyFinal.watchfiles
+                  pyFinal.pyyaml
+                ];
+                dontCheckRuntimeDeps = true;
+                doCheck = false;
+              });
+            })
+          ];
         };
+
+        # Downstream consumers who apply `mcp-nixos.overlays.default` get both
+        # mcp-nixos itself and the fastmcp 3 upgrade needed to satisfy our
+        # fastmcp>=3.2.0 dependency against nixpkgs that still ships 2.x.
+        overlays.default = nixpkgs.lib.composeExtensions self.overlays.fastmcp3 (
+          final: _: {
+            mcp-nixos = mkMcpNixos { pkgs = final; };
+          }
+        );
 
         lib.mkMcpNixos = mkMcpNixos;
       };
@@ -88,35 +121,7 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [
-              (final: prev: {
-                # Upgrade fastmcp to 3.2.4 ahead of nixpkgs.
-                # Mirrors nixpkgs PR #510339 (PrefectHQ/fastmcp v3.2.4). Can be removed
-                # once that PR merges and our flake input moves past it.
-                pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-                  (pyFinal: pyPrev: {
-                    fastmcp = pyPrev.fastmcp.overridePythonAttrs (old: rec {
-                      version = "3.2.4";
-                      src = prev.fetchFromGitHub {
-                        owner = "PrefectHQ";
-                        repo = "fastmcp";
-                        tag = "v${version}";
-                        hash = "sha256-rJpxPvqAaa6/vXhG1+R9dI32cY/54e6I+F/zyBVoqBM=";
-                      };
-                      dependencies = (old.dependencies or [ ]) ++ [
-                        pyFinal.griffelib
-                        pyFinal.opentelemetry-api
-                        pyFinal.uncalled-for
-                        pyFinal.watchfiles
-                        pyFinal.pyyaml
-                      ];
-                      dontCheckRuntimeDeps = true;
-                      doCheck = false;
-                    });
-                  })
-                ];
-              })
-            ];
+            overlays = [ self.overlays.fastmcp3 ];
           };
         in
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     # "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "fastmcp>=2.11.0",
+    "fastmcp>=3.2.0",
     "requests>=2.32.4",
     "beautifulsoup4>=4.13.4",
 ]

--- a/tests/test_flake_inputs.py
+++ b/tests/test_flake_inputs.py
@@ -20,8 +20,10 @@ from mcp_nixos.server import (
     nix,
 )
 
-# Get underlying function from MCP tool wrapper
-nix_fn = nix.fn
+# Get underlying function from MCP tool wrapper.
+# FastMCP 2.x wraps @mcp.tool() functions as FunctionTool (with .fn); FastMCP 3.x
+# returns the plain async function. Support both.
+nix_fn = getattr(nix, "fn", nix)
 
 
 @pytest.mark.unit

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,9 +3,11 @@
 import pytest
 from mcp_nixos.server import nix, nix_versions
 
-# Get underlying functions from MCP tool wrappers
-nix_fn = nix.fn
-nix_versions_fn = nix_versions.fn
+# Get underlying functions from MCP tool wrappers.
+# FastMCP 2.x wraps @mcp.tool() functions as FunctionTool (with .fn); FastMCP 3.x
+# returns the plain async function. Support both.
+nix_fn = getattr(nix, "fn", nix)
+nix_versions_fn = getattr(nix_versions, "fn", nix_versions)
 
 
 def assert_plain_text(result: str) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,9 +18,11 @@ from unittest.mock import Mock, patch
 import pytest
 from mcp_nixos.server import nix, nix_versions
 
-# Get underlying functions from MCP tool wrappers
-nix_fn = nix.fn
-nix_versions_fn = nix_versions.fn
+# Get underlying functions from MCP tool wrappers.
+# FastMCP 2.x wraps @mcp.tool() functions as FunctionTool (with .fn); FastMCP 3.x
+# returns the plain async function. Support both.
+nix_fn = getattr(nix, "fn", nix)
+nix_versions_fn = getattr(nix_versions, "fn", nix_versions)
 
 
 class TestNixToolValidation:


### PR DESCRIPTION
## Summary

Upgrades the project to FastMCP 3.x to unblock downstream nixpkgs work (see #127 from @JamieMagee — `ha-mcp` in nixpkgs is moving to fastmcp 3.x via [NixOS/nixpkgs#511658](https://github.com/NixOS/nixpkgs/pull/511658)).

- Bump `pyproject.toml` dep floor: `fastmcp>=2.11.0` → `fastmcp>=3.2.0`.
- Override `python3Packages.fastmcp` in our flake to build PrefectHQ/fastmcp v3.2.4 with the new transitive deps (`griffelib`, `opentelemetry-api`, `uncalled-for`, `watchfiles`, `pyyaml`). Mirrors pending [nixpkgs PR #510339](https://github.com/NixOS/nixpkgs/pull/510339); removable once it lands and our flake input moves past it.
- Split the override into `overlays.fastmcp3` and compose it into `overlays.default` so downstream consumers applying `mcp-nixos.overlays.default` get the fastmcp upgrade too (caught by codex peer review — without this, the published overlay still builds against the consumer's nixpkgs fastmcp 2.x and can fail the `>=3.2.0` pin).
- Update tests that used `nix.fn` / `nix_versions.fn` to `getattr(tool, "fn", tool)` — FastMCP 2.x and the PyPI wheel of 3.2.4 wrap `@mcp.tool()` as `FunctionTool` (has `.fn`), while the nix-built 3.2.4 returns a plain async function. Same shim already used in `.pi/extensions/mcp-nixos.ts`.

## Compat notes

- **Breaking for consumers on fastmcp 2.x.** After this lands, the next release should be a minor bump (e.g. `2.4.0`) rather than a patch.
- Left `py-key-value-aio` at nixpkgs' 0.3.0 in the override — fastmcp 3.2.4 technically wants `py-key-value-aio[filetree,keyring,memory]>=0.4.4`, which only affects the OAuth proxy import path (`aiofile`). Doesn't affect any mcp-nixos runtime path. Tracked in #129 as a follow-up; resolves naturally once nixpkgs PR #510339 merges.

## Test plan

- [x] `nix build .#mcp-nixos` succeeds (unit tests run in `checkPhase`, 174 passing).
- [x] `nix flake check` clean.
- [x] Downstream-simulation eval: `pkgs = import <nixpkgs> { overlays = [ self.overlays.default ]; }` resolves `fastmcp == 3.2.4`.
- [x] stdio transport boots (FastMCP 3.2.4 banner prints).
- [x] HTTP transport boots on `127.0.0.1:18444/mcp`.
- [x] `.pi/extensions/mcp-nixos.ts` wrapper: live `stats` call returns correct plain-text output (fastmcp 3's plain-function decorator behavior handled by existing `getattr(tool, "fn", tool)` shim).
- [x] `ruff format --check`, `ruff check`, `mypy` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped minimum fastmcp requirement to 3.2.0 and updated package overlay to provide FastMCP 3.x by default.
  * Ensured default overlays include both the overridden fastmcp and the existing package export.

* **Documentation**
  * Updated tool query scope (added "browse" and "cache", kept "options" as a legacy alias).
  * Noted FastMCP 3.x compatibility and async/concurrency behavior.

* **Tests**
  * Made tests resilient to both FastMCP 2.x and 3.x wrapper behaviors by resolving tool callables dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->