### PR TITLE
fix(flake): drop pydocket to unblock aarch64 docker build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,13 +90,20 @@
                   tag = "v${version}";
                   hash = "sha256-rJpxPvqAaa6/vXhG1+R9dI32cY/54e6I+F/zyBVoqBM=";
                 };
-                dependencies = (old.dependencies or [ ]) ++ [
-                  pyFinal.griffelib
-                  pyFinal.opentelemetry-api
-                  pyFinal.uncalled-for
-                  pyFinal.watchfiles
-                  pyFinal.pyyaml
-                ];
+                # Drop pydocket (moved to optional-dependencies.tasks upstream in
+                # nixpkgs PR #510339) and add fastmcp 3's new transitive deps.
+                # pydocket's build pulls in lupa → luajit, which fails to link on
+                # aarch64-linux (bundled libluajit.a is in the wrong format), and
+                # we don't use fastmcp task features.
+                dependencies =
+                  builtins.filter (d: (d.pname or "") != "pydocket") (old.dependencies or [ ])
+                  ++ [
+                    pyFinal.griffelib
+                    pyFinal.opentelemetry-api
+                    pyFinal.uncalled-for
+                    pyFinal.watchfiles
+                    pyFinal.pyyaml
+                  ];
                 dontCheckRuntimeDeps = true;
                 doCheck = false;
               });


### PR DESCRIPTION
## Summary

Fixes the main-branch docker-build (arm64) CI failure that appeared right after #130 merged.

Root cause: our fastmcp 3 overlay inherits all of fastmcp 2's runtime deps via \`old.dependencies\`, which includes \`pydocket\`. \`pydocket\` pulls in \`lupa\`, and \`lupa\` fails to link on aarch64-linux — its bundled \`libluajit.a\` is in the wrong format:

\`\`\`
ld: /build/lupa-2.7/third-party/luajit21/src/libluajit.a:
    error adding symbols: file in wrong format
\`\`\`

Upstream [nixpkgs PR #510339](https://github.com/NixOS/nixpkgs/pull/510339) — which our override mirrors — moves \`pydocket\` out of runtime deps into \`optional-dependencies.tasks\` for fastmcp 3. We don't use fastmcp's task features, so dropping pydocket from the inherited deps matches upstream intent and removes the whole lupa/luajit aarch64 build from our closure.

## Test plan

- [x] \`nix build .#mcp-nixos\` succeeds locally (aarch64-darwin).
- [x] Eval for aarch64-linux consumer shows \`fastmcp.propagatedBuildInputs\` no longer contains pydocket or lupa.
- [x] \`from fastmcp import FastMCP\` and \`from mcp_nixos.server import mcp\` both succeed.
- [x] 174 unit tests pass.
- [ ] CI: main-branch docker-build (arm64) passes after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to improve tooling compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->