### PR TITLE
fix(server): targeted error for action=info on source=flakes

### DIFF
--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -10,6 +10,7 @@ All responses are formatted as human-readable plain text for optimal LLM interac
 """
 
 import asyncio
+import json
 import os
 import re
 import sys
@@ -259,9 +260,9 @@ async def nix(
         if not query:
             return error('Name required for info. Example: {"action": "info", "query": "firefox"}')
         if source == "flakes":
+            example = json.dumps({"action": "search", "source": "flakes", "query": query})
             return error(
-                "action=info is not supported for source=flakes. Use action=search instead. "
-                f'Example: {{"action": "search", "source": "flakes", "query": "{query}"}}.'
+                f"action=info is not supported for source=flakes. Use action=search instead. Example: {example}."
             )
         if source == "nixos":
             if type not in ["package", "packages", "option", "options"]:

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -258,6 +258,11 @@ async def nix(
     elif action == "info":
         if not query:
             return error('Name required for info. Example: {"action": "info", "query": "firefox"}')
+        if source == "flakes":
+            return error(
+                "action=info is not supported for source=flakes. Use action=search instead. "
+                f'Example: {{"action": "search", "source": "flakes", "query": "{query}"}}.'
+            )
         if source == "nixos":
             if type not in ["package", "packages", "option", "options"]:
                 return error(
@@ -340,7 +345,7 @@ async def nix(
         # Validate type parameter for flake-inputs
         # Note: "packages" is accepted as alias for "list" (default type parameter)
         if type not in ["list", "ls", "read", "packages"]:
-            return error("Type must be list|ls|read for flake-inputs")
+            return error("Type must be one of: list, ls, read for flake-inputs")
 
         # Handle limit for read operation
         read_limit = limit
@@ -362,7 +367,7 @@ async def nix(
                 return error("Query required for read (input:path format)")
             return await _flake_inputs_read(flake_dir, query, read_limit)
         else:
-            return error("Type must be list|ls|read for flake-inputs")
+            return error("Type must be one of: list, ls, read for flake-inputs")
 
     elif action == "cache":
         if not query:

--- a/tests/test_flake_inputs.py
+++ b/tests/test_flake_inputs.py
@@ -353,7 +353,8 @@ class TestNixToolFlakeInputsRouting:
     async def test_invalid_type(self):
         result = await nix_fn(action="flake-inputs", type="invalid")
         assert "Error" in result
-        assert "list|ls|read" in result
+        assert "list" in result and "ls" in result and "read" in result
+        assert "|" not in result
 
     @pytest.mark.asyncio
     async def test_ls_requires_query(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -53,6 +53,23 @@ class TestNixToolValidation:
         assert "nixos" in result and "home-manager" in result
 
     @pytest.mark.asyncio
+    async def test_info_flakes_redirects_to_search(self):
+        """action=info with source=flakes should point at action=search with a JSON example."""
+        result = await nix_fn(action="info", source="flakes", query="test")
+        assert "Error" in result
+        assert '"action": "search"' in result
+        assert '"source": "flakes"' in result
+
+    @pytest.mark.asyncio
+    async def test_info_unknown_source_uses_prose_not_pipes(self):
+        """Unknown sources for action=info keep the allowlist error but use commas, not pipes."""
+        result = await nix_fn(action="info", source="bogus", query="test")
+        assert "Error" in result
+        assert "Unknown source" in result
+        assert "|" not in result
+        assert "nixos, home-manager" in result
+
+    @pytest.mark.asyncio
     async def test_browse_nixos_redirects_to_search(self):
         """action=browse with source=nixos should redirect to the correct search/info form (#125)."""
         result = await nix_fn(action="browse", source="nixos")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,6 +25,7 @@ nix_fn = getattr(nix, "fn", nix)
 nix_versions_fn = getattr(nix_versions, "fn", nix_versions)
 
 
+@pytest.mark.unit
 class TestNixToolValidation:
     """Test input validation for the nix tool."""
 


### PR DESCRIPTION
## Summary

Fixes a small UX bug in the `nix` tool's info handler. When a caller passed `action=info` with `source=flakes`, the server responded with a generic allowlist error even though `flakes` is a perfectly valid source — just not for `action=info`. The new branch recognizes this case and points the caller at the correct shape with a copy-pasteable JSON example.

### Before

```
nix(action="info", source="flakes", query="test")
# -> Error (ERROR): Unknown source: 'flakes'. For action=info, must be one of: nixos, home-manager, darwin, flakehub, nixvim, wiki, nix-dev, noogle, nixhub.
```

### After

```
nix(action="info", source="flakes", query="test")
# -> Error (ERROR): action=info is not supported for source=flakes. Use action=search instead. Example: {"action": "search", "source": "flakes", "query": "test"}.
```

Unrelated unknown sources (e.g. `source=bogus`) still get the allowlist error — untouched.

### Also

Converted the one remaining pipe-separated list in `action=flake-inputs` (`list|ls|read`) to prose (`one of: list, ls, read`), matching the v2.3.2 tool-description cleanup (#123/#125) that replaced pipes with commas elsewhere.

## Test plan

- [x] `nix develop --command bash -c "ruff format . && ruff check . && mypy mcp_nixos && pytest tests/ -m unit --no-header -q"` — all green (174 passed).
- [x] New unit test `test_info_flakes_redirects_to_search` asserts the JSON example is present in the error.
- [x] New unit test `test_info_unknown_source_uses_prose_not_pipes` asserts the allowlist error is still returned for truly unknown sources AND contains no `|` character.
- [x] Existing `test_invalid_type` in `test_flake_inputs.py` updated to match the new prose wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer validation messages for flake-inputs type (lists of allowed options shown plainly).
  * Rejects attempts to use info action with flakes and directs users to use search instead.
  * Improved wording for unknown source errors (allowed sources listed clearly, no pipe-delimited text).

* **Tests**
  * Added/updated tests to verify the above error messages and redirected payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->