### PR TITLE
feat: add action=store for reading /nix/store paths (closes #126)

### DIFF
--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -146,15 +146,17 @@ async function runNixosTool(tool: "nix" | "nix_versions", args: unknown, signal?
 const nixToolParams = Type.Object({
 	action: Type.String({
 		description:
-			"One of: search, info, stats, browse, channels, flake-inputs, cache. " +
+			"One of: search, info, stats, browse, channels, flake-inputs, cache, store. " +
 			"search = keyword lookup; info = details for a specific name; " +
-			"browse = walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only).",
+			"browse = walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only); " +
+			"store = read files or list directories at an explicit /nix/store/ path.",
 	}),
 	query: Type.Optional(
 		Type.String({
 			description:
 				"Search term for 'search', exact name for 'info', prefix path for 'browse'. " +
-				"For flake-inputs: input_name or input:path. Omit for 'stats'/'channels'.",
+				"For flake-inputs: input_name or input:path. For store: absolute /nix/store/ path. " +
+				"Omit for 'stats'/'channels'.",
 		}),
 	),
 	source: Type.Optional(
@@ -163,7 +165,7 @@ const nixToolParams = Type.Object({
 				"Data source for search/info/stats/browse/cache. One of: nixos (default), " +
 				"home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. " +
 				"For action=flake-inputs, this may instead be a path to a flake directory; " +
-				"omit/default to use the current project.",
+				"omit/default to use the current project. Ignored by action=store.",
 		}),
 	),
 	type: Type.Optional(
@@ -171,14 +173,15 @@ const nixToolParams = Type.Object({
 			description:
 				"Sub-type of query. For source=nixos with action=search, one of: " +
 				"packages, options, programs, flakes. For source=nixos with action=info, one of: " +
-				"package, option. For flake-inputs, one of: list, ls, read. Ignored by most other sources.",
+				"package, option. For flake-inputs, one of: list, ls, read. For store, one of: " +
+				"ls, read. Ignored by most other sources.",
 		}),
 	),
 	channel: Type.Optional(
 		Type.String({ description: "NixOS channel: unstable (default), stable, or a release like 25.05." }),
 	),
 	limit: Type.Optional(
-		Type.Integer({ description: "Max results. 1-100 (or 1-2000 for flake-inputs read). Default 20." }),
+		Type.Integer({ description: "Max results. 1-100 (or 1-2000 for flake-inputs/store read). Default 20." }),
 	),
 	version: Type.Optional(
 		Type.String({ description: "Only used by action=cache. Package version (default: latest)." }),
@@ -205,6 +208,8 @@ const nixToolDescription = [
 	'  Search the wiki:          {"action": "search", "query": "zfs", "source": "wiki"}',
 	'  List channels:            {"action": "channels"}',
 	'  Check binary cache:       {"action": "cache", "query": "firefox"}',
+	'  List a store directory:   {"action": "store", "type": "ls", "query": "/nix/store/abc...-foo"}',
+	'  Read a store file:        {"action": "store", "type": "read", "query": "/nix/store/abc...-foo/bin/foo"}',
 	"",
 	"Notes:",
 	"  - To search NixOS options, use action=search with type=options. Do NOT use action=browse for source=nixos.",

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -382,7 +382,7 @@ async def nix(
     elif action == "store":
         if type not in ["ls", "read"]:
             return error(
-                "Type must be ls|read for store. "
+                "Type must be one of: ls, read for store. "
                 'Example: {"action": "store", "type": "ls", "query": "/nix/store/<hash>-<name>"}'
             )
         if not query:

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -114,6 +114,8 @@ from .sources import (
     _stats_nixos,
     _stats_nixvim,
     _stats_noogle,
+    _store_ls,
+    _store_read,
     es_query,
     get_channel_suggestions,
     get_channels,
@@ -162,30 +164,33 @@ def env_bool(name: str, default: bool = False) -> bool:
 async def nix(
     action: Annotated[
         str,
-        "One of: search, info, stats, browse, channels, flake-inputs, cache. "
+        "One of: search, info, stats, browse, channels, flake-inputs, cache, store. "
         "Use 'search' for keyword lookup, 'info' for details about a specific name, "
-        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only).",
+        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only). "
+        "'store' reads files or lists directories at an explicit /nix/store/ path.",
     ],
     query: Annotated[
         str,
         "Search term for 'search', exact name for 'info', prefix path for 'browse'. "
-        "For flake-inputs: input_name or input:path. Leave empty for 'stats'/'channels'.",
+        "For flake-inputs: input_name or input:path. For store: absolute /nix/store/ path. "
+        "Leave empty for 'stats'/'channels'.",
     ] = "",
     source: Annotated[
         str,
         "Data source for search/info/stats/browse/cache. One of: nixos (default), "
         "home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. "
         "For action=flake-inputs, this may instead be a path to a flake directory; "
-        "omit/default to use the current project.",
+        "omit/default to use the current project. Ignored by action=store.",
     ] = "nixos",
     type: Annotated[
         str,
         "Sub-type of query. For source=nixos with action=search, one of: "
         "packages, options, programs, flakes. For source=nixos with action=info, one of: "
-        "package, option. For flake-inputs, one of: list, ls, read. Ignored by most other sources.",
+        "package, option. For flake-inputs, one of: list, ls, read. For store, one of: "
+        "ls, read. Ignored by most other sources.",
     ] = "packages",
     channel: Annotated[str, "NixOS channel: unstable (default), stable, or a release like 25.05."] = "unstable",
-    limit: Annotated[int, "Max results. 1-100 (or 1-2000 for flake-inputs read)."] = 20,
+    limit: Annotated[int, "Max results. 1-100 (or 1-2000 for flake-inputs/store read)."] = 20,
     version: Annotated[str, "Only used by action=cache. Package version (default: latest)."] = "latest",
     system: Annotated[str, "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all."] = "",
 ) -> str:
@@ -201,6 +206,8 @@ async def nix(
       Search the NixOS wiki:    {"action": "search", "query": "zfs", "source": "wiki"}
       List channels:            {"action": "channels"}
       Check binary cache:       {"action": "cache", "query": "firefox"}
+      List a store directory:   {"action": "store", "type": "ls", "query": "/nix/store/abc...-foo"}
+      Read a store file:        {"action": "store", "type": "read", "query": "/nix/store/abc...-foo/bin/foo"}
 
     Notes:
       - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
@@ -209,10 +216,13 @@ async def nix(
       - Omit parameters you don't need; do not pass empty strings for optional args.
       - For package version history use the separate `nix_versions` tool.
     """
-    # Limit validation: flake-inputs read allows up to 2000, others limited to 100
+    # Limit validation: flake-inputs/store read allow up to 2000, others limited to 100
     if action == "flake-inputs" and type == "read":
         if not 1 <= limit <= MAX_LINE_LIMIT:
             return error(f"Limit must be 1-{MAX_LINE_LIMIT} for flake-inputs read")
+    elif action == "store" and type == "read":
+        if not 1 <= limit <= MAX_LINE_LIMIT:
+            return error(f"Limit must be 1-{MAX_LINE_LIMIT} for store read")
     elif not 1 <= limit <= 100:
         return error("Limit must be 1-100")
 
@@ -369,10 +379,31 @@ async def nix(
             return error("Package name required for cache action")
         return await _check_binary_cache(query, version, system)
 
+    elif action == "store":
+        if type not in ["ls", "read"]:
+            return error(
+                "Type must be ls|read for store. "
+                'Example: {"action": "store", "type": "ls", "query": "/nix/store/<hash>-<name>"}'
+            )
+        if not query:
+            return error(
+                "Query required for store (absolute /nix/store/ path). "
+                'Example: {"action": "store", "type": "ls", "query": "/nix/store/<hash>-<name>"}'
+            )
+        if type == "ls":
+            return await _store_ls(query)
+
+        # type == "read": default limit behavior mirrors flake-inputs read.
+        read_limit = limit
+        if limit == 20:  # Default was used, apply DEFAULT_LINE_LIMIT
+            read_limit = DEFAULT_LINE_LIMIT
+        read_limit = min(read_limit, MAX_LINE_LIMIT)
+        return await _store_read(query, read_limit)
+
     else:
         return error(
             f"Unknown action: {action!r}. Must be one of: "
-            "search, info, stats, browse, channels, flake-inputs, cache. "
+            "search, info, stats, browse, channels, flake-inputs, cache, store. "
             'Example: {"action": "search", "query": "firefox"}'
         )
 
@@ -635,6 +666,9 @@ __all__ = [
     "_flake_inputs_list",
     "_flake_inputs_ls",
     "_flake_inputs_read",
+    # Store functions
+    "_store_ls",
+    "_store_read",
 ]
 
 

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -391,7 +391,12 @@ async def nix(
                 'Example: {"action": "store", "type": "ls", "query": "/nix/store/<hash>-<name>"}'
             )
         if type == "ls":
-            return await _store_ls(query)
+            # Match _store_read's default-promotion so a bare call returns a
+            # useful window of entries for large /nix/store directories
+            # instead of only the first 20.
+            ls_limit = limit if limit != 20 else DEFAULT_LINE_LIMIT
+            ls_limit = min(ls_limit, MAX_LINE_LIMIT)
+            return await _store_ls(query, ls_limit)
 
         # type == "read": default limit behavior mirrors flake-inputs read.
         read_limit = limit

--- a/mcp_nixos/sources/__init__.py
+++ b/mcp_nixos/sources/__init__.py
@@ -97,6 +97,12 @@ from .noogle import (
     _stats_noogle,
 )
 
+# Direct /nix/store path access
+from .store import (
+    _store_ls,
+    _store_read,
+)
+
 # NixOS Wiki
 from .wiki import (
     _info_wiki,
@@ -167,4 +173,7 @@ __all__ = [
     "_flake_inputs_list",
     "_flake_inputs_ls",
     "_flake_inputs_read",
+    # Store
+    "_store_ls",
+    "_store_read",
 ]

--- a/mcp_nixos/sources/store.py
+++ b/mcp_nixos/sources/store.py
@@ -1,0 +1,134 @@
+"""Direct /nix/store path inspection for MCP-NixOS server.
+
+Exposes ls/read over an explicit absolute store path. Reuses the same safety
+guarantees as `flake_inputs`: paths are resolved and must stay under
+`/nix/store/`, and binary files are refused with a size-annotated error.
+Unlike `flake_inputs`, no `nix` subprocess is required — files are read
+directly from disk.
+"""
+
+import asyncio
+import os
+import stat
+
+from ..config import MAX_FILE_SIZE
+from ..utils import (
+    _format_size,
+    _is_binary_file,
+    _read_file_with_limit,
+    _validate_store_path,
+    error,
+)
+
+
+def _normalize_store_path(query: str) -> tuple[bool, str, str]:
+    """Validate a user-supplied store path.
+
+    Returns (ok, normalized_path, error_message).
+    """
+    if not query or not query.strip():
+        return False, "", "Store path required (e.g., '/nix/store/<hash>-<name>')"
+
+    path = query.strip()
+
+    if not path.startswith("/"):
+        return False, "", f"Absolute store path required, got {query!r}"
+
+    if not _validate_store_path(path):
+        return False, "", f"Invalid store path: must stay within /nix/store/, got {query!r}"
+
+    return True, path, ""
+
+
+async def _store_ls(query: str) -> str:
+    """List the contents of a directory inside /nix/store."""
+    ok, target_path, err_msg = _normalize_store_path(query)
+    if not ok:
+        return error(err_msg, "INVALID_PATH")
+
+    if not os.path.exists(target_path):
+        return error(f"Path not found: {target_path}", "NOT_FOUND")
+
+    if not os.path.isdir(target_path):
+        return error(f"Not a directory: {target_path}", "NOT_DIRECTORY")
+
+    try:
+        entries = await asyncio.to_thread(os.listdir, target_path)
+    except PermissionError:
+        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
+    except OSError as exc:
+        return error(f"Cannot list directory: {exc}", "OS_ERROR")
+
+    if not entries:
+        return f"Directory '{target_path}' is empty."
+
+    dirs: list[str] = []
+    files: list[tuple[str, int | None]] = []
+
+    for entry in sorted(entries):
+        entry_path = os.path.join(target_path, entry)
+        try:
+            st = os.stat(entry_path)
+            if stat.S_ISDIR(st.st_mode):
+                dirs.append(entry)
+            else:
+                files.append((entry, st.st_size))
+        except OSError:
+            files.append((entry, None))
+
+    lines = [f"Contents of {target_path} ({len(dirs)} dirs, {len(files)} files):", ""]
+
+    for name in dirs:
+        lines.append(f"  {name}/")
+
+    for name, size in files:
+        size_str = f" ({_format_size(size)})" if size is not None else ""
+        lines.append(f"  {name}{size_str}")
+
+    return "\n".join(lines)
+
+
+async def _store_read(query: str, limit: int) -> str:
+    """Read a text file inside /nix/store with a line limit."""
+    ok, target_path, err_msg = _normalize_store_path(query)
+    if not ok:
+        return error(err_msg, "INVALID_PATH")
+
+    if not os.path.exists(target_path):
+        return error(f"File not found: {target_path}", "NOT_FOUND")
+
+    if os.path.isdir(target_path):
+        return error(f"'{target_path}' is a directory. Use type='ls' to list contents.", "IS_DIRECTORY")
+
+    try:
+        file_size = os.path.getsize(target_path)
+    except OSError as exc:
+        return error(f"Cannot access file: {exc}", "OS_ERROR")
+
+    if file_size > MAX_FILE_SIZE:
+        return error(
+            f"File too large: {_format_size(file_size)} (max {_format_size(MAX_FILE_SIZE)})",
+            "FILE_TOO_LARGE",
+        )
+
+    is_binary = await asyncio.to_thread(_is_binary_file, target_path)
+    if is_binary:
+        return error(
+            f"Binary file detected: {target_path} ({_format_size(file_size)})",
+            "BINARY_FILE",
+        )
+
+    try:
+        lines, total_lines = await asyncio.to_thread(_read_file_with_limit, target_path, limit)
+    except PermissionError:
+        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
+    except OSError as exc:
+        return error(f"Cannot read file: {exc}", "OS_ERROR")
+
+    header = [f"File: {target_path}", f"Size: {_format_size(file_size)}", ""]
+
+    if total_lines > limit:
+        header.append(f"(Showing {limit} of {total_lines} lines)")
+        header.append("")
+
+    return "\n".join(header + lines)

--- a/mcp_nixos/sources/store.py
+++ b/mcp_nixos/sources/store.py
@@ -21,10 +21,13 @@ from ..utils import (
 )
 
 
-def _normalize_store_path(query: str) -> tuple[bool, str, str]:
-    """Validate a user-supplied store path.
+def _validate_query(query: str) -> tuple[bool, str, str]:
+    """Check a user-supplied store path for structural problems.
 
-    Returns (ok, normalized_path, error_message).
+    The returned path is the stripped input — not canonicalised. Callers that
+    need to cross filesystem boundaries safely should rely on
+    `_validate_store_path` (which already rejects traversal attempts) rather
+    than re-deriving from this value. Returns `(ok, path, error_message)`.
     """
     if not query or not query.strip():
         return False, "", "Store path required (e.g., '/nix/store/<hash>-<name>')"
@@ -40,31 +43,15 @@ def _normalize_store_path(query: str) -> tuple[bool, str, str]:
     return True, path, ""
 
 
-async def _store_ls(query: str) -> str:
-    """List the contents of a directory inside /nix/store."""
-    ok, target_path, err_msg = _normalize_store_path(query)
-    if not ok:
-        return error(err_msg, "INVALID_PATH")
+def _scan_directory(target_path: str) -> tuple[list[str], list[tuple[str, int | None]]]:
+    """Collect (dirs, files-with-sizes) for a directory in one sync pass.
 
-    if not os.path.exists(target_path):
-        return error(f"Path not found: {target_path}", "NOT_FOUND")
-
-    if not os.path.isdir(target_path):
-        return error(f"Not a directory: {target_path}", "NOT_DIRECTORY")
-
-    try:
-        entries = await asyncio.to_thread(os.listdir, target_path)
-    except PermissionError:
-        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
-    except OSError as exc:
-        return error(f"Cannot list directory: {exc}", "OS_ERROR")
-
-    if not entries:
-        return f"Directory '{target_path}' is empty."
-
+    Raises PermissionError / OSError on listdir failure so the caller can
+    distinguish them. Per-entry stat failures fall back to `size=None`.
+    """
+    entries = os.listdir(target_path)
     dirs: list[str] = []
     files: list[tuple[str, int | None]] = []
-
     for entry in sorted(entries):
         entry_path = os.path.join(target_path, entry)
         try:
@@ -75,6 +62,32 @@ async def _store_ls(query: str) -> str:
                 files.append((entry, st.st_size))
         except OSError:
             files.append((entry, None))
+    return dirs, files
+
+
+async def _store_ls(query: str) -> str:
+    """List the contents of a directory inside /nix/store."""
+    ok, target_path, err_msg = _validate_query(query)
+    if not ok:
+        return error(err_msg, "INVALID_PATH")
+
+    if not os.path.exists(target_path):
+        return error(f"Path not found: {target_path}", "NOT_FOUND")
+
+    if not os.path.isdir(target_path):
+        return error(f"Not a directory: {target_path}", "NOT_DIRECTORY")
+
+    # Scan + per-entry stat run in a single worker thread so even large
+    # /nix/store directories never block the event loop.
+    try:
+        dirs, files = await asyncio.to_thread(_scan_directory, target_path)
+    except PermissionError:
+        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
+    except OSError as exc:
+        return error(f"Cannot list directory: {exc}", "OS_ERROR")
+
+    if not dirs and not files:
+        return f"Directory '{target_path}' is empty."
 
     lines = [f"Contents of {target_path} ({len(dirs)} dirs, {len(files)} files):", ""]
 
@@ -90,7 +103,7 @@ async def _store_ls(query: str) -> str:
 
 async def _store_read(query: str, limit: int) -> str:
     """Read a text file inside /nix/store with a line limit."""
-    ok, target_path, err_msg = _normalize_store_path(query)
+    ok, target_path, err_msg = _validate_query(query)
     if not ok:
         return error(err_msg, "INVALID_PATH")
 
@@ -100,10 +113,19 @@ async def _store_read(query: str, limit: int) -> str:
     if os.path.isdir(target_path):
         return error(f"'{target_path}' is a directory. Use type='ls' to list contents.", "IS_DIRECTORY")
 
+    # Catch PermissionError before the broad OSError so permission problems
+    # surface cleanly instead of being flattened into OS_ERROR (and to match
+    # what _is_binary_file does internally — without this check, an unreadable
+    # file would be misreported as BINARY_FILE below).
     try:
         file_size = os.path.getsize(target_path)
+    except PermissionError:
+        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
     except OSError as exc:
         return error(f"Cannot access file: {exc}", "OS_ERROR")
+
+    if not os.access(target_path, os.R_OK):
+        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
 
     if file_size > MAX_FILE_SIZE:
         return error(

--- a/mcp_nixos/sources/store.py
+++ b/mcp_nixos/sources/store.py
@@ -114,18 +114,13 @@ async def _store_read(query: str, limit: int) -> str:
         return error(f"'{target_path}' is a directory. Use type='ls' to list contents.", "IS_DIRECTORY")
 
     # Catch PermissionError before the broad OSError so permission problems
-    # surface cleanly instead of being flattened into OS_ERROR (and to match
-    # what _is_binary_file does internally — without this check, an unreadable
-    # file would be misreported as BINARY_FILE below).
+    # surface cleanly instead of being flattened into OS_ERROR.
     try:
         file_size = os.path.getsize(target_path)
     except PermissionError:
         return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
     except OSError as exc:
         return error(f"Cannot access file: {exc}", "OS_ERROR")
-
-    if not os.access(target_path, os.R_OK):
-        return error(f"Permission denied: {target_path}", "PERMISSION_ERROR")
 
     if file_size > MAX_FILE_SIZE:
         return error(

--- a/mcp_nixos/sources/store.py
+++ b/mcp_nixos/sources/store.py
@@ -65,8 +65,13 @@ def _scan_directory(target_path: str) -> tuple[list[str], list[tuple[str, int | 
     return dirs, files
 
 
-async def _store_ls(query: str) -> str:
-    """List the contents of a directory inside /nix/store."""
+async def _store_ls(query: str, limit: int) -> str:
+    """List the contents of a directory inside /nix/store.
+
+    `limit` caps how many entries (dirs + files combined, sorted with dirs
+    first) we actually print, so a caller passing `limit=1` against a large
+    store directory doesn't get the entire listing back.
+    """
     ok, target_path, err_msg = _validate_query(query)
     if not ok:
         return error(err_msg, "INVALID_PATH")
@@ -86,15 +91,28 @@ async def _store_ls(query: str) -> str:
     except OSError as exc:
         return error(f"Cannot list directory: {exc}", "OS_ERROR")
 
-    if not dirs and not files:
+    total_dirs = len(dirs)
+    total_files = len(files)
+    total = total_dirs + total_files
+    if total == 0:
         return f"Directory '{target_path}' is empty."
 
-    lines = [f"Contents of {target_path} ({len(dirs)} dirs, {len(files)} files):", ""]
+    # Truncate dirs+files as a single combined list, keeping dirs first
+    # (same display order as the non-truncated case).
+    shown_dirs = dirs[:limit]
+    remaining = max(0, limit - len(shown_dirs))
+    shown_files = files[:remaining]
+    shown_total = len(shown_dirs) + len(shown_files)
 
-    for name in dirs:
+    header = f"Contents of {target_path} ({total_dirs} dirs, {total_files} files):"
+    if shown_total < total:
+        header += f" showing {shown_total} of {total}"
+    lines = [header, ""]
+
+    for name in shown_dirs:
         lines.append(f"  {name}/")
 
-    for name, size in files:
+    for name, size in shown_files:
         size_str = f" ({_format_size(size)})" if size is not None else ""
         lines.append(f"  {name}{size_str}")
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -53,7 +53,16 @@ def _find_text_file_in_dir(root: str, max_files: int = 200) -> str | None:
 
 
 def _find_binary_file_in_dir(root: str, max_files: int = 500) -> str | None:
-    """Find a binary file under `root`, or None if none found quickly."""
+    """Find a binary file under `root` below `MAX_FILE_SIZE`, or None if none found quickly.
+
+    The size cap matters because `_store_read` rejects files over
+    `MAX_FILE_SIZE` with `FILE_TOO_LARGE` before the binary check runs —
+    and many /nix/store binaries (compiled libraries, CA bundles, etc.)
+    exceed the 1 MB default. Picking one over the cap would short-circuit
+    the test on an unrelated error.
+    """
+    from mcp_nixos.config import MAX_FILE_SIZE
+
     count = 0
     for dirpath, _dirnames, filenames in os.walk(root):
         for name in filenames:
@@ -64,7 +73,8 @@ def _find_binary_file_in_dir(root: str, max_files: int = 500) -> str | None:
             try:
                 if os.path.islink(path):
                     continue
-                if os.path.getsize(path) == 0:
+                size = os.path.getsize(path)
+                if size == 0 or size >= MAX_FILE_SIZE:
                     continue
                 with open(path, "rb") as f:
                     chunk = f.read(4096)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -287,7 +287,11 @@ class TestStoreRouting:
             query="/nix/store/0000000000000000000000000000000000000000-x",
         )
         assert "Error" in result
-        assert "ls" in result and "read" in result
+        # Anchor on the specific wording so future error rewrites can't
+        # silently satisfy a permissive substring match (e.g. "fails",
+        # "thread" happen to contain "ls"/"read").
+        assert "Type must be" in result
+        assert "ls, read" in result or "ls or read" in result
 
     @pytest.mark.asyncio
     async def test_missing_query_for_ls(self):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,339 @@
+"""Tests for direct /nix/store path access (action=store)."""
+
+import os
+import tempfile
+
+import pytest
+from mcp_nixos.server import (
+    _store_ls,
+    _store_read,
+    nix,
+)
+
+# Get underlying function from MCP tool wrapper (see tests/test_flake_inputs.py).
+nix_fn = getattr(nix, "fn", nix)
+
+
+def _pick_real_store_dir() -> str | None:
+    """Return an existing /nix/store/<entry> directory, or None if not available."""
+    if not os.path.isdir("/nix/store"):
+        return None
+    for entry in os.listdir("/nix/store"):
+        candidate = f"/nix/store/{entry}"
+        if os.path.isdir(candidate) and not os.path.islink(candidate):
+            return candidate
+    return None
+
+
+def _find_text_file_in_dir(root: str, max_files: int = 200) -> str | None:
+    """Find a small text file under `root`, or None if none found quickly."""
+    count = 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            count += 1
+            if count > max_files:
+                return None
+            path = os.path.join(dirpath, name)
+            try:
+                if os.path.islink(path):
+                    continue
+                size = os.path.getsize(path)
+                if size == 0 or size > 64 * 1024:
+                    continue
+                with open(path, "rb") as f:
+                    chunk = f.read(4096)
+                if b"\x00" in chunk:
+                    continue
+                # Ensure it decodes as UTF-8-ish
+                chunk.decode("utf-8", errors="strict")
+                return path
+            except (OSError, UnicodeDecodeError):
+                continue
+    return None
+
+
+def _find_binary_file_in_dir(root: str, max_files: int = 500) -> str | None:
+    """Find a binary file under `root`, or None if none found quickly."""
+    count = 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            count += 1
+            if count > max_files:
+                return None
+            path = os.path.join(dirpath, name)
+            try:
+                if os.path.islink(path):
+                    continue
+                if os.path.getsize(path) == 0:
+                    continue
+                with open(path, "rb") as f:
+                    chunk = f.read(4096)
+                if b"\x00" in chunk:
+                    return path
+            except OSError:
+                continue
+    return None
+
+
+@pytest.mark.unit
+class TestStoreLsPathValidation:
+    """Reject non-store and path-traversal queries before touching the filesystem."""
+
+    @pytest.mark.asyncio
+    async def test_empty_query_rejected(self):
+        result = await _store_ls("")
+        assert "Error" in result
+        assert "store path required" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_relative_path_rejected(self):
+        result = await _store_ls("nix/store/foo")
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+    @pytest.mark.asyncio
+    async def test_non_store_path_rejected(self):
+        result = await _store_ls("/tmp")
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+        assert "/nix/store/" in result
+
+    @pytest.mark.asyncio
+    async def test_etc_passwd_rejected(self):
+        result = await _store_ls("/etc/passwd")
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self):
+        result = await _store_ls("/nix/store/../etc/passwd")
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+
+@pytest.mark.unit
+class TestStoreLsRealPath:
+    """Exercise the happy path against a real /nix/store entry if available."""
+
+    @pytest.mark.asyncio
+    async def test_ls_real_store_dir(self):
+        store_dir = _pick_real_store_dir()
+        if store_dir is None:
+            pytest.skip("/nix/store not available or empty")
+
+        result = await _store_ls(store_dir)
+        assert "Error" not in result
+        assert store_dir in result
+        assert "dirs" in result and "files" in result
+
+
+@pytest.mark.unit
+class TestStoreLsMissing:
+    """NOT_FOUND for a validly shaped but non-existent store path."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_path(self):
+        if not os.path.isdir("/nix/store"):
+            pytest.skip("/nix/store not available")
+
+        bogus = "/nix/store/0000000000000000000000000000000000000000-does-not-exist"
+        result = await _store_ls(bogus)
+        assert "Error" in result
+        assert "NOT_FOUND" in result
+
+
+@pytest.mark.unit
+class TestStoreReadPathValidation:
+    """Same guardrails as _store_ls but for read."""
+
+    @pytest.mark.asyncio
+    async def test_empty_query_rejected(self):
+        result = await _store_read("", 20)
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+    @pytest.mark.asyncio
+    async def test_non_store_path_rejected(self):
+        result = await _store_read("/tmp/foo", 20)
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self):
+        result = await _store_read("/nix/store/../etc/passwd", 20)
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+
+@pytest.mark.unit
+class TestStoreReadNotFound:
+    """read on a missing file returns NOT_FOUND."""
+
+    @pytest.mark.asyncio
+    async def test_missing_file(self):
+        if not os.path.isdir("/nix/store"):
+            pytest.skip("/nix/store not available")
+
+        bogus = "/nix/store/0000000000000000000000000000000000000000-nope/bin/nope"
+        result = await _store_read(bogus, 20)
+        assert "Error" in result
+        assert "NOT_FOUND" in result
+
+
+@pytest.mark.unit
+class TestStoreReadIsDirectory:
+    """read on a directory returns IS_DIRECTORY with a helpful hint."""
+
+    @pytest.mark.asyncio
+    async def test_directory_target(self):
+        store_dir = _pick_real_store_dir()
+        if store_dir is None:
+            pytest.skip("/nix/store not available or empty")
+
+        result = await _store_read(store_dir, 20)
+        assert "Error" in result
+        assert "IS_DIRECTORY" in result
+        assert "type='ls'" in result
+
+
+@pytest.mark.unit
+class TestStoreReadTextFile:
+    """Read a real text file out of /nix/store and confirm formatting + truncation."""
+
+    @pytest.mark.asyncio
+    async def test_read_text_file(self):
+        store_dir = _pick_real_store_dir()
+        if store_dir is None:
+            pytest.skip("/nix/store not available or empty")
+        text_file = _find_text_file_in_dir(store_dir)
+        if text_file is None:
+            pytest.skip("no small text file found in first store entry")
+
+        result = await _store_read(text_file, 2000)
+        assert "Error" not in result
+        assert f"File: {text_file}" in result
+        assert "Size:" in result
+
+    @pytest.mark.asyncio
+    async def test_read_truncates_with_limit(self):
+        # Use a tempfile mounted... no — _validate_store_path requires /nix/store/
+        # So instead find a real multi-line text file in /nix/store.
+        store_dir = _pick_real_store_dir()
+        if store_dir is None:
+            pytest.skip("/nix/store not available or empty")
+
+        # Find a file with at least a few lines
+        candidate: str | None = None
+        for dirpath, _dirnames, filenames in os.walk(store_dir):
+            for name in filenames:
+                path = os.path.join(dirpath, name)
+                try:
+                    if os.path.islink(path):
+                        continue
+                    size = os.path.getsize(path)
+                    if size == 0 or size > 64 * 1024:
+                        continue
+                    with open(path, "rb") as f:
+                        chunk = f.read(4096)
+                    if b"\x00" in chunk:
+                        continue
+                    # Needs at least 3 lines for a meaningful truncation test
+                    if chunk.count(b"\n") >= 3:
+                        candidate = path
+                        break
+                except OSError:
+                    continue
+            if candidate is not None:
+                break
+
+        if candidate is None:
+            pytest.skip("no multi-line text file found in first store entry")
+
+        result = await _store_read(candidate, 1)
+        assert "Error" not in result
+        assert "Showing 1 of" in result
+
+
+@pytest.mark.unit
+class TestStoreReadBinaryFile:
+    """read on a binary file returns a BINARY_FILE error that includes the size."""
+
+    @pytest.mark.asyncio
+    async def test_read_binary_file(self):
+        store_dir = _pick_real_store_dir()
+        if store_dir is None:
+            pytest.skip("/nix/store not available or empty")
+        binary_file = _find_binary_file_in_dir(store_dir)
+        if binary_file is None:
+            pytest.skip("no binary file found in first store entry")
+
+        result = await _store_read(binary_file, 20)
+        assert "Error" in result
+        assert "BINARY_FILE" in result
+        assert binary_file in result
+        # Size annotation should be present (bytes/KB/MB/GB)
+        assert any(unit in result for unit in (" B)", " KB)", " MB)", " GB)"))
+
+
+@pytest.mark.unit
+class TestStoreRouting:
+    """Routing of action=store through the top-level nix() tool."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_type(self):
+        result = await nix_fn(
+            action="store",
+            type="invalid",
+            query="/nix/store/0000000000000000000000000000000000000000-x",
+        )
+        assert "Error" in result
+        assert "ls" in result and "read" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_query_for_ls(self):
+        result = await nix_fn(action="store", type="ls")
+        assert "Error" in result
+        assert "Query required" in result
+        assert "/nix/store/" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_query_for_read(self):
+        result = await nix_fn(action="store", type="read")
+        assert "Error" in result
+        assert "Query required" in result
+
+    @pytest.mark.asyncio
+    async def test_read_limit_validation(self):
+        result = await nix_fn(
+            action="store",
+            type="read",
+            query="/nix/store/0000000000000000000000000000000000000000-x/file",
+            limit=3000,
+        )
+        assert "Error" in result
+        assert "2000" in result
+
+    @pytest.mark.asyncio
+    async def test_non_store_path_rejected_through_tool(self):
+        result = await nix_fn(action="store", type="ls", query="/tmp")
+        assert "Error" in result
+        assert "INVALID_PATH" in result
+
+
+@pytest.mark.unit
+class TestStorePlainText:
+    """Store output must remain plain text (no JSON/XML leakage)."""
+
+    @pytest.mark.asyncio
+    async def test_error_output_is_plain_text(self):
+        result = await _store_ls("/tmp")
+        # No JSON braces or XML tags in error output
+        assert not result.strip().startswith("{")
+        assert not result.strip().startswith("<")
+
+    @pytest.mark.asyncio
+    async def test_read_error_is_plain_text(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = await _store_read(tmpdir, 20)
+            assert not result.strip().startswith("{")
+            assert not result.strip().startswith("<")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -81,18 +81,21 @@ class TestStoreLsPathValidation:
 
     @pytest.mark.asyncio
     async def test_empty_query_rejected(self):
+        """Empty query rejected."""
         result = await _store_ls("", 500)
         assert "Error" in result
         assert "store path required" in result.lower()
 
     @pytest.mark.asyncio
     async def test_relative_path_rejected(self):
+        """Relative path rejected."""
         result = await _store_ls("nix/store/foo", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_non_store_path_rejected(self):
+        """Non store path rejected."""
         result = await _store_ls("/tmp", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
@@ -100,12 +103,14 @@ class TestStoreLsPathValidation:
 
     @pytest.mark.asyncio
     async def test_etc_passwd_rejected(self):
+        """Etc passwd rejected."""
         result = await _store_ls("/etc/passwd", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_path_traversal_rejected(self):
+        """Path traversal rejected."""
         result = await _store_ls("/nix/store/../etc/passwd", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
@@ -117,6 +122,7 @@ class TestStoreLsRealPath:
 
     @pytest.mark.asyncio
     async def test_ls_real_store_dir(self):
+        """Ls real store dir."""
         store_dir = _pick_real_store_dir()
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
@@ -161,6 +167,7 @@ class TestStoreLsMissing:
 
     @pytest.mark.asyncio
     async def test_nonexistent_path(self):
+        """Nonexistent path."""
         if not os.path.isdir("/nix/store"):
             pytest.skip("/nix/store not available")
 
@@ -176,18 +183,21 @@ class TestStoreReadPathValidation:
 
     @pytest.mark.asyncio
     async def test_empty_query_rejected(self):
+        """Empty query rejected."""
         result = await _store_read("", 20)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_non_store_path_rejected(self):
+        """Non store path rejected."""
         result = await _store_read("/tmp/foo", 20)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_path_traversal_rejected(self):
+        """Path traversal rejected."""
         result = await _store_read("/nix/store/../etc/passwd", 20)
         assert "Error" in result
         assert "INVALID_PATH" in result
@@ -199,6 +209,7 @@ class TestStoreReadNotFound:
 
     @pytest.mark.asyncio
     async def test_missing_file(self):
+        """Missing file."""
         if not os.path.isdir("/nix/store"):
             pytest.skip("/nix/store not available")
 
@@ -214,6 +225,7 @@ class TestStoreReadIsDirectory:
 
     @pytest.mark.asyncio
     async def test_directory_target(self):
+        """Directory target."""
         store_dir = _pick_real_store_dir()
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
@@ -230,6 +242,7 @@ class TestStoreReadTextFile:
 
     @pytest.mark.asyncio
     async def test_read_text_file(self):
+        """Read text file."""
         store_dir = _pick_real_store_dir()
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
@@ -246,6 +259,7 @@ class TestStoreReadTextFile:
     async def test_read_truncates_with_limit(self):
         # Use a tempfile mounted... no — _validate_store_path requires /nix/store/
         # So instead find a real multi-line text file in /nix/store.
+        """Read truncates with limit."""
         store_dir = _pick_real_store_dir()
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
@@ -288,6 +302,7 @@ class TestStoreReadBinaryFile:
 
     @pytest.mark.asyncio
     async def test_read_binary_file(self):
+        """Read binary file."""
         store_dir = _pick_real_store_dir()
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
@@ -309,6 +324,7 @@ class TestStoreRouting:
 
     @pytest.mark.asyncio
     async def test_invalid_type(self):
+        """Invalid type."""
         result = await nix_fn(
             action="store",
             type="invalid",
@@ -323,6 +339,7 @@ class TestStoreRouting:
 
     @pytest.mark.asyncio
     async def test_missing_query_for_ls(self):
+        """Missing query for ls."""
         result = await nix_fn(action="store", type="ls")
         assert "Error" in result
         assert "Query required" in result
@@ -330,12 +347,14 @@ class TestStoreRouting:
 
     @pytest.mark.asyncio
     async def test_missing_query_for_read(self):
+        """Missing query for read."""
         result = await nix_fn(action="store", type="read")
         assert "Error" in result
         assert "Query required" in result
 
     @pytest.mark.asyncio
     async def test_read_limit_validation(self):
+        """Read limit validation."""
         result = await nix_fn(
             action="store",
             type="read",
@@ -347,6 +366,7 @@ class TestStoreRouting:
 
     @pytest.mark.asyncio
     async def test_non_store_path_rejected_through_tool(self):
+        """Non store path rejected through tool."""
         result = await nix_fn(action="store", type="ls", query="/tmp")
         assert "Error" in result
         assert "INVALID_PATH" in result
@@ -358,6 +378,7 @@ class TestStorePlainText:
 
     @pytest.mark.asyncio
     async def test_error_output_is_plain_text(self):
+        """Error output is plain text."""
         result = await _store_ls("/tmp", 500)
         # No JSON braces or XML tags in error output
         assert not result.strip().startswith("{")
@@ -365,6 +386,7 @@ class TestStorePlainText:
 
     @pytest.mark.asyncio
     async def test_read_error_is_plain_text(self):
+        """Read error is plain text."""
         with tempfile.TemporaryDirectory() as tmpdir:
             result = await _store_read(tmpdir, 20)
             assert not result.strip().startswith("{")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -81,32 +81,32 @@ class TestStoreLsPathValidation:
 
     @pytest.mark.asyncio
     async def test_empty_query_rejected(self):
-        result = await _store_ls("")
+        result = await _store_ls("", 500)
         assert "Error" in result
         assert "store path required" in result.lower()
 
     @pytest.mark.asyncio
     async def test_relative_path_rejected(self):
-        result = await _store_ls("nix/store/foo")
+        result = await _store_ls("nix/store/foo", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_non_store_path_rejected(self):
-        result = await _store_ls("/tmp")
+        result = await _store_ls("/tmp", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
         assert "/nix/store/" in result
 
     @pytest.mark.asyncio
     async def test_etc_passwd_rejected(self):
-        result = await _store_ls("/etc/passwd")
+        result = await _store_ls("/etc/passwd", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
     @pytest.mark.asyncio
     async def test_path_traversal_rejected(self):
-        result = await _store_ls("/nix/store/../etc/passwd")
+        result = await _store_ls("/nix/store/../etc/passwd", 500)
         assert "Error" in result
         assert "INVALID_PATH" in result
 
@@ -121,10 +121,38 @@ class TestStoreLsRealPath:
         if store_dir is None:
             pytest.skip("/nix/store not available or empty")
 
-        result = await _store_ls(store_dir)
+        result = await _store_ls(store_dir, 500)
         assert "Error" not in result
         assert store_dir in result
-        assert "dirs" in result and "files" in result
+        # `_pick_real_store_dir` may pick a valid but empty store output
+        # (nixpkgs produces empty directories for some derivations). Accept
+        # either the "Contents of ..." header or the empty-directory message.
+        assert ("dirs" in result and "files" in result) or "is empty" in result
+
+    @pytest.mark.asyncio
+    async def test_ls_honours_limit(self):
+        """limit=1 against a real store dir must not dump the full listing."""
+        if not os.path.isdir("/nix/store"):
+            pytest.skip("/nix/store not available")
+        big_dir = None
+        for entry in sorted(os.listdir("/nix/store"))[:50]:
+            candidate = os.path.join("/nix/store", entry)
+            if os.path.isdir(candidate):
+                try:
+                    if len(os.listdir(candidate)) >= 2:
+                        big_dir = candidate
+                        break
+                except OSError:
+                    continue
+        if big_dir is None:
+            pytest.skip("no /nix/store entry with 2+ children found")
+
+        result = await _store_ls(big_dir, 1)
+        assert "Error" not in result
+        assert "showing 1 of" in result
+        # Exactly one entry line (two-space indent) should follow the header/blank line.
+        entry_lines = [ln for ln in result.splitlines() if ln.startswith("  ")]
+        assert len(entry_lines) == 1, f"expected one entry line, got {entry_lines}"
 
 
 @pytest.mark.unit
@@ -137,7 +165,7 @@ class TestStoreLsMissing:
             pytest.skip("/nix/store not available")
 
         bogus = "/nix/store/0000000000000000000000000000000000000000-does-not-exist"
-        result = await _store_ls(bogus)
+        result = await _store_ls(bogus, 500)
         assert "Error" in result
         assert "NOT_FOUND" in result
 
@@ -330,7 +358,7 @@ class TestStorePlainText:
 
     @pytest.mark.asyncio
     async def test_error_output_is_plain_text(self):
-        result = await _store_ls("/tmp")
+        result = await _store_ls("/tmp", 500)
         # No JSON braces or XML tags in error output
         assert not result.strip().startswith("{")
         assert not result.strip().startswith("<")


### PR DESCRIPTION
## Summary

- Adds a new `store` action on the `nix` tool with two subtypes via `type`:
  - `type=ls` — list the contents of a directory at an explicit `/nix/store/<hash>-<name>[/subpath]` path, with per-entry sizes.
  - `type=read` — read a text file at an explicit store path, respecting `limit` (default 500 lines, capped at 2000 — same ceiling used by `flake-inputs read`).
- New module `mcp_nixos/sources/store.py`; wired through `mcp_nixos/sources/__init__.py` and `mcp_nixos/server.py`. No new runtime dependencies — files are read directly with stdlib, no `nix` subprocess needed.
- `.pi/extensions/mcp-nixos.ts` schema and docstring examples updated so Pi users see the new action too.

## Security

Reuses `_validate_store_path` from `mcp_nixos/utils.py`, which calls `os.path.realpath` and then checks that the result starts with `/nix/store/`. This means:

- Non-store paths (`/tmp`, `/etc/passwd`, `/home/...`) are rejected with `INVALID_PATH` before any filesystem access.
- Path-traversal attempts like `/nix/store/../etc/passwd` resolve to `/etc/passwd`, fail the prefix check, and are rejected.
- Relative paths and empty queries are refused up front.

Binary files are refused with a size-annotated `BINARY_FILE` error (same pattern as `flake-inputs read`), and files larger than `MAX_FILE_SIZE` (1 MiB) return `FILE_TOO_LARGE`.

## Sample invocations

```json
{"action": "store", "type": "ls",   "query": "/nix/store/abc...-foo"}
{"action": "store", "type": "ls",   "query": "/nix/store/abc...-foo/share"}
{"action": "store", "type": "read", "query": "/nix/store/abc...-foo/bin/foo"}
{"action": "store", "type": "read", "query": "/nix/store/abc...-foo/bin/foo", "limit": 500}
```

Output remains plain text (no JSON/XML leakage) to match server conventions.

## Test plan

- [x] `pytest tests/test_store.py -m unit` — 22 new unit tests covering:
  - path validation (empty, relative, non-store, `/etc/passwd`, traversal)
  - `ls` on a real store directory
  - `ls` on a non-existent store path (`NOT_FOUND`)
  - `read` on a real text file in `/nix/store` (format + `Size:` header)
  - `read` truncation via `limit`
  - `read` on a binary file (`BINARY_FILE` with size annotation)
  - `read` on a missing file (`NOT_FOUND`)
  - `read` on a directory (`IS_DIRECTORY` with `type='ls'` hint)
  - routing through `nix()` for bad `type`, missing query, `limit > 2000`, non-store path
  - plain-text output assertions
- [x] `ruff format . && ruff check . && mypy mcp_nixos` — clean, no suppressions
- [x] `pytest tests/ -m unit` — all 196 unit tests pass
- [x] `nix build .#mcp-nixos` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a store action to the nix tool to inspect absolute /nix/store paths: list directories (ls) and read files (read) with path validation, size-aware responses, binary-file detection, and enforced line/read limits.

* **Documentation**
  * Updated parameter docs and examples for action=store, clarifying query format, type restrictions, and adjusted limit guidance.

* **Tests**
  * Added tests for validation, error cases, truncation, binary handling, and tool routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->