### PR TITLE
fix(flake): make fastmcp3 overlay work on older nixpkgs (closes #135)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,15 +95,19 @@
                 # pydocket's build pulls in lupa → luajit, which fails to link on
                 # aarch64-linux (bundled libluajit.a is in the wrong format), and
                 # we don't use fastmcp task features.
-                dependencies =
-                  builtins.filter (d: (d.pname or "") != "pydocket") (old.dependencies or [ ])
-                  ++ [
-                    pyFinal.griffelib
-                    pyFinal.opentelemetry-api
-                    pyFinal.uncalled-for
-                    pyFinal.watchfiles
-                    pyFinal.pyyaml
-                  ];
+                #
+                # griffelib and uncalled-for are recent additions to nixos-unstable
+                # (March 2026) and absent from stable channels. Use upstream if the
+                # consumer's nixpkgs has them; otherwise fall back to our inline
+                # definitions so `inputs.nixpkgs.follows = "nixpkgs"` works against
+                # older pins. See issue #135.
+                dependencies = builtins.filter (d: (d.pname or "") != "pydocket") (old.dependencies or [ ]) ++ [
+                  (pyFinal.griffelib or (pyFinal.callPackage ./nix/griffelib.nix { }))
+                  pyFinal.opentelemetry-api
+                  (pyFinal.uncalled-for or (pyFinal.callPackage ./nix/uncalled-for.nix { }))
+                  pyFinal.watchfiles
+                  pyFinal.pyyaml
+                ];
                 dontCheckRuntimeDeps = true;
                 doCheck = false;
               });

--- a/nix/griffelib.nix
+++ b/nix/griffelib.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pdm-backend,
+  uv-dynamic-versioning,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "griffelib";
+  version = "2.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mkdocstrings";
+    repo = "griffe";
+    tag = finalAttrs.version;
+    hash = "sha256-Fxa9lrBVQ/enVLiU7hUc0d5x9ItI19EGnbxa7MX6Plc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/griffelib";
+
+  build-system = [
+    hatchling
+    pdm-backend
+    uv-dynamic-versioning
+  ];
+
+  pythonImportsCheck = [ "griffe" ];
+  doCheck = false;
+
+  meta = {
+    description = "Signatures for entire Python programs";
+    homepage = "https://github.com/mkdocstrings/griffe";
+    license = lib.licenses.isc;
+  };
+})

--- a/nix/uncalled-for.nix
+++ b/nix/uncalled-for.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "uncalled-for";
+  version = "0.3.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "chrisguidry";
+    repo = "uncalled-for";
+    tag = finalAttrs.version;
+    hash = "sha256-+akXLsfto3FNbkpsPPwN1DQmvu3BpTafRbqLmLwtqek=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  pythonImportsCheck = [ "uncalled_for" ];
+  doCheck = false;
+
+  meta = {
+    description = "Async dependency injection for Python functions";
+    homepage = "https://github.com/chrisguidry/uncalled-for";
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
## Summary

- Guard `pyFinal.griffelib` and `pyFinal.uncalled-for` references in the `fastmcp3` overlay with `or` fallbacks, so the overlay works against consumer nixpkgs that lacks them.
- Add minimal inline fallback derivations at `nix/griffelib.nix` (2.0.2) and `nix/uncalled-for.nix` (0.3.1), matching the derivations upstream in nixos-unstable.

## Why

`griffelib` was added to nixos-unstable on 2026-03-18 and `uncalled-for` shortly after. Neither exists in stable (nixos-25.11) or in older unstable pins. Any downstream consumer using `inputs.nixpkgs.follows = "nixpkgs"` against such a pin hits:

```
error: attribute 'griffelib' missing
  at .../flake.nix:101:21
```

The reporter (#135) proposed swapping `griffelib` → `griffe`, but that would *build* wrong at runtime: fastmcp 3.2.4 explicitly requires `griffelib>=2.0.0` (a distinct PyPI package split from `griffe` 2.x), and nixpkgs `griffe` is still 1.x. The `or`-fallback path is correct for both stable- and unstable-pinned consumers, and the fallback files are trivially deletable once nixpkgs PR #510339 lands and our pin moves past it.

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix build .#default` succeeds on current unstable (upstream `griffelib` is used)
- [x] Simulated a pre-griffelib consumer (overlay stripping both attrs) — `fastmcp` builds using the inline fallbacks; dependency list includes `griffelib` and `uncalled-for` from local derivations
- [x] `nix fmt --check` passes
- [x] Codex peer review: no blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Python dependency resolution with conditional fallback support for package availability
  * Added support for griffelib (v2.0.2) and uncalled-for (v0.3.1) packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->