### PR TITLE
fix: survive non-UTF-8 .env in CWD on startup (#144)

### DIFF
--- a/mcp_nixos/__init__.py
+++ b/mcp_nixos/__init__.py
@@ -5,9 +5,20 @@ This package provides MCP resources and tools for interacting with NixOS package
 system options, Home Manager configuration options, and nix-darwin macOS configuration options.
 """
 
+import os
 import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+
+# Sidestep an upstream crash: fastmcp's top-level import constructs a
+# pydantic-settings `Settings()`, which eagerly reads `.env` from the caller's
+# CWD via python-dotenv. A non-UTF-8 `.env` (git-crypt ciphertext, sops-
+# encrypted dotenv, any binary blob) takes the whole server down with a
+# UnicodeDecodeError *before* the MCP stdio handshake ever runs — the client
+# just sees mcp-nixos fail to start. We don't read any FASTMCP_* settings from
+# `.env`, so neutralising the lookup is safe. Respect an explicit override.
+# See issue #144 and https://github.com/jlowin/fastmcp (fastmcp/__init__.py).
+os.environ.setdefault("FASTMCP_ENV_FILE", os.devnull)
 
 try:
     __version__ = version("mcp-nixos")

--- a/tests/test_env_file_safety.py
+++ b/tests/test_env_file_safety.py
@@ -28,10 +28,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _run_import_in(cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    """Run `from mcp_nixos.server import main` in a fresh Python process rooted at `cwd`."""
+    """Run `import mcp_nixos.server` in a fresh Python process rooted at `cwd`."""
     full_env = os.environ.copy()
     # Let the subprocess find the in-tree mcp_nixos without install.
     full_env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT), full_env.get("PYTHONPATH", "")]))
+    # Strip any inherited FASTMCP_ENV_FILE so the regression tests exercise the
+    # *default* path (mcp_nixos/__init__.py's setdefault). If the caller wants
+    # to assert the explicit-override behavior, they pass it via `env`.
+    full_env.pop("FASTMCP_ENV_FILE", None)
     if env:
         full_env.update(env)
 

--- a/tests/test_env_file_safety.py
+++ b/tests/test_env_file_safety.py
@@ -71,11 +71,7 @@ def test_explicit_fastmcp_env_file_is_preserved(tmp_path: Path) -> None:
     valid_env = tmp_path / "custom.env"
     valid_env.write_text("SOME_FASTMCP_VAR=hello\n", encoding="utf-8")
 
-    result = _run_import_in(tmp_path, env={"FASTMCP_ENV_FILE": str(valid_env)})
-
-    assert result.returncode == 0, f"stderr={result.stderr!r}"
-
-    import_check = subprocess.run(
+    result = subprocess.run(
         [
             sys.executable,
             "-c",
@@ -87,11 +83,11 @@ def test_explicit_fastmcp_env_file_is_preserved(tmp_path: Path) -> None:
         text=True,
         timeout=30,
     )
-    assert import_check.returncode == 0
-    assert import_check.stdout.strip() == str(valid_env)
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    assert result.stdout.strip() == str(valid_env)
 
 
-def test_default_fastmcp_env_file_points_to_devnull() -> None:
+def test_default_fastmcp_env_file_points_to_devnull(tmp_path: Path) -> None:
     """Import mcp_nixos with no FASTMCP_ENV_FILE set; it should default to os.devnull."""
     env = {k: v for k, v in os.environ.items() if k != "FASTMCP_ENV_FILE"}
     env["PYTHONPATH"] = str(REPO_ROOT)
@@ -102,6 +98,7 @@ def test_default_fastmcp_env_file_points_to_devnull() -> None:
             "-c",
             "import os; import mcp_nixos; print(os.environ['FASTMCP_ENV_FILE'])",
         ],
+        cwd=str(tmp_path),
         env=env,
         capture_output=True,
         text=True,

--- a/tests/test_env_file_safety.py
+++ b/tests/test_env_file_safety.py
@@ -1,0 +1,112 @@
+"""
+Regression tests for issue #144: mcp-nixos must start even when the CWD
+contains a non-UTF-8 `.env`.
+
+fastmcp's top-level import eagerly constructs a pydantic-settings `Settings()`
+which runs python-dotenv on `.env` in the process CWD. A binary / git-crypt
+/ sops-encrypted dotenv file used to take the whole server down with a
+UnicodeDecodeError before the MCP handshake ever ran. `mcp_nixos/__init__.py`
+sets `FASTMCP_ENV_FILE=os.devnull` as a default to sidestep that path.
+
+These tests spawn fresh subprocesses so we're actually exercising import-time
+behavior; importing mcp_nixos in the test runner's already-loaded process
+doesn't exercise the crash.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_import_in(cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run `from mcp_nixos.server import main` in a fresh Python process rooted at `cwd`."""
+    full_env = os.environ.copy()
+    # Let the subprocess find the in-tree mcp_nixos without install.
+    full_env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT), full_env.get("PYTHONPATH", "")]))
+    if env:
+        full_env.update(env)
+
+    script = textwrap.dedent(
+        """
+        import mcp_nixos.server
+        print("OK")
+        """
+    ).strip()
+
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_startup_survives_non_utf8_dotenv(tmp_path: Path) -> None:
+    """Non-UTF-8 bytes in ./.env must not crash import of mcp_nixos.server."""
+    (tmp_path / ".env").write_bytes(b"\x9d\x9e\xff\x00binary garbage\xc3\x28")
+
+    result = _run_import_in(tmp_path)
+
+    assert result.returncode == 0, (
+        "mcp_nixos.server failed to import with a non-UTF-8 .env in CWD. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+    assert "UnicodeDecodeError" not in result.stderr
+
+
+def test_explicit_fastmcp_env_file_is_preserved(tmp_path: Path) -> None:
+    """If the user sets FASTMCP_ENV_FILE explicitly, we must not clobber it."""
+    valid_env = tmp_path / "custom.env"
+    valid_env.write_text("SOME_FASTMCP_VAR=hello\n", encoding="utf-8")
+
+    result = _run_import_in(tmp_path, env={"FASTMCP_ENV_FILE": str(valid_env)})
+
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+
+    import_check = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import mcp_nixos; print(os.environ['FASTMCP_ENV_FILE'])",
+        ],
+        cwd=str(tmp_path),
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT), "FASTMCP_ENV_FILE": str(valid_env)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert import_check.returncode == 0
+    assert import_check.stdout.strip() == str(valid_env)
+
+
+def test_default_fastmcp_env_file_points_to_devnull() -> None:
+    """Import mcp_nixos with no FASTMCP_ENV_FILE set; it should default to os.devnull."""
+    env = {k: v for k, v in os.environ.items() if k != "FASTMCP_ENV_FILE"}
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import mcp_nixos; print(os.environ['FASTMCP_ENV_FILE'])",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    assert result.stdout.strip() == os.devnull


### PR DESCRIPTION
## Summary

Closes #144.

`fastmcp`'s top-level import eagerly constructs a pydantic-settings `Settings()`, which runs python-dotenv on `.env` in the process CWD. A binary/git-crypt/sops-encrypted dotenv takes the whole server down with a `UnicodeDecodeError` **before** the MCP stdio handshake ever runs — clients just see mcp-nixos fail to start.

Minimal fix: set `FASTMCP_ENV_FILE=os.devnull` via `os.environ.setdefault` at the top of `mcp_nixos/__init__.py`, before any submodule imports `fastmcp`. We don't read any `FASTMCP_*` values from `.env`, so pointing fastmcp at a known-empty path is safe. Users who legitimately want a fastmcp dotenv can still export `FASTMCP_ENV_FILE` explicitly — we only set the default when unset.

## Reproducer (before)

```
$ mkdir /tmp/repro && printf '\x9d\x9e\xffbinary' > /tmp/repro/.env
$ cd /tmp/repro && python -c "from mcp_nixos.server import main"
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9d in position 0: invalid start byte
```

After this patch: clean import, no crash.

## Test plan

- [x] Reproduced issue #144 against main (non-UTF-8 `.env` → UnicodeDecodeError)
- [x] Verified fix clears it locally (clean import from the same CWD)
- [x] Verified explicit `FASTMCP_ENV_FILE=/path/to/file` override still respected
- [x] Added `tests/test_env_file_safety.py` — 3 regression tests that spawn fresh Python subprocesses (import-time behavior can't be exercised in a single process):
  - non-UTF-8 `.env` in CWD → `import mcp_nixos.server` succeeds
  - explicit `FASTMCP_ENV_FILE` is preserved through import
  - unset `FASTMCP_ENV_FILE` defaults to `os.devnull` after import
- [x] Full local run: 336 tests pass (333 baseline + 3 new), ruff + mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents startup crashes by neutralizing eager environment-file loading at import time—defaults the fastmcp env file to a safe location when not explicitly set.

* **Tests**
  * Added tests verifying import-time behavior: surviving non-UTF-8 env files, preserving an explicitly provided env-file, and using the safe default when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->