### PR TITLE
feat: improve LLM discoverability (closes #146)

### DIFF
--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -139,7 +139,38 @@ from .utils import (
 )
 
 # Create MCP server instance
-mcp = FastMCP("mcp-nixos", version=__version__)
+#
+# The `instructions` string is surfaced to clients via the MCP
+# InitializeResult and is how hosts prime the model on when to
+# reach for this server versus Bash/web search. Keep it short,
+# intent-focused, and explicit about triggers; see GH #146.
+_SERVER_INSTRUCTIONS = (
+    "Use this server for any question about nixpkgs packages, NixOS / home-manager / "
+    "nix-darwin / nixvim options, flakes, FlakeHub, channels, the binary cache, store "
+    "paths, or the NixOS wiki and nix.dev docs. It queries live APIs (search.nixos.org, "
+    "NixHub, FlakeHub, cache.nixos.org) and is faster and more current than `nix search`, "
+    "scraping search.nixos.org by hand, or running `gh api` against NixOS/nixpkgs.\n\n"
+    "Trigger on any mention of a Nix package name, attribute path, NixOS / "
+    "home-manager / darwin option, channel name (unstable, 25.05, ...), flake input, "
+    "or `/nix/store/` path. Use even when you think you know the answer — your training "
+    "data lags nixpkgs by months.\n\n"
+    "Two tools are exposed:\n"
+    "- `nix` — unified search/info/stats/browse/channels/flake-inputs/cache/store across "
+    "NixOS, Home Manager, nix-darwin, Nixvim, flakes, FlakeHub, NixHub, the NixOS wiki, "
+    "nix.dev, and Noogle. For package version *history* pair with `nix_versions`.\n"
+    "- `nix_versions` — commit-accurate history from NixHub (which nixpkgs commit "
+    "shipped version X, what attribute path, which platforms).\n\n"
+    "Common intents → calls:\n"
+    '  "is package X in channel Y?"         → nix(action=info, query=X, channel=Y)\n'
+    '  "which channels are available?"      → nix(action=channels)\n'
+    '  "search NixOS options for X"         → nix(action=search, query=X, type=options)\n'
+    '  "home-manager option for X"          → nix(action=search, source=home-manager, query=X)\n'
+    '  "does X have a binary cache?"        → nix(action=cache, query=X)\n'
+    '  "read /nix/store/<path>"             → nix(action=store, type=read, query=<path>)\n'
+    '  "which commit shipped X version Y?"  → nix_versions(package=X, version=Y)\n'
+)
+
+mcp = FastMCP("mcp-nixos", version=__version__, instructions=_SERVER_INSTRUCTIONS)
 
 
 _TRUE_TOKENS = {"1", "true", "yes", "y", "on"}
@@ -199,20 +230,35 @@ async def nix(
 ) -> str:
     """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
 
-    Examples (the JSON shape matters — copy exactly):
-      Search NixOS packages:    {"action": "search", "query": "firefox"}
-      Search NixOS options:     {"action": "search", "query": "nginx", "type": "options"}
-      Get a package's details:  {"action": "info", "query": "firefox"}
-      Get an option's details:  {"action": "info", "query": "services.nginx.enable", "type": "option"}
-      Search Home Manager:      {"action": "search", "query": "git", "source": "home-manager"}
-      Browse HM option tree:    {"action": "browse", "query": "programs", "source": "home-manager"}
-      Search the NixOS wiki:    {"action": "search", "query": "zfs", "source": "wiki"}
-      Search nix.dev docs:      {"action": "search", "query": "flakes", "source": "nix-dev"}
-      Read a nix.dev page:      {"action": "info", "query": "tutorials/nix-language", "source": "nix-dev"}
-      List channels:            {"action": "channels"}
-      Check binary cache:       {"action": "cache", "query": "firefox"}
-      List a store directory:   {"action": "store", "type": "ls", "query": "/nix/store/abc...-foo"}
-      Read a store file:        {"action": "store", "type": "read", "query": "/nix/store/abc...-foo/bin/foo"}
+    Use this tool for anything touching nixpkgs, Nix channels, flakes, NixOS / home-manager /
+    darwin options, the binary cache, or /nix/store paths — even when you think you know the
+    answer. Your training data lags nixpkgs by months. Prefer this over `nix search`, scraping
+    search.nixos.org, or running `gh api` against NixOS/nixpkgs.
+
+    INTENTS → CALLS (copy the JSON shape exactly):
+      "is package X in channel Y?"        → {"action": "info", "query": "X", "channel": "Y"}
+      "search for package X"              → {"action": "search", "query": "X"}
+      "which channels are available?"     → {"action": "channels"}
+      "which commit is channel X at?"     → {"action": "channels"}  (revision shown per channel)
+      "search NixOS options for X"        → {"action": "search", "query": "X", "type": "options"}
+      "get option details for X"          → {"action": "info", "query": "X", "type": "option"}
+      "home-manager option for X"         → {"action": "search", "query": "X", "source": "home-manager"}
+      "darwin option for X"               → {"action": "search", "query": "X", "source": "darwin"}
+      "nixvim option for X"               → {"action": "search", "query": "X", "source": "nixvim"}
+      "what programs does pkg X provide?" → {"action": "search", "query": "X", "type": "programs"}
+      "count packages/options"            → {"action": "stats"}
+      "browse hm option tree under P"     → {"action": "browse", "query": "P", "source": "home-manager"}
+      "does X have a binary cache?"       → {"action": "cache", "query": "X"}
+      "search the NixOS wiki for X"       → {"action": "search", "query": "X", "source": "wiki"}
+      "search nix.dev docs"               → {"action": "search", "query": "X", "source": "nix-dev"}
+      "read a nix.dev page"               → {"action": "info", "query": "tutorials/nix-language", "source": "nix-dev"}
+      "list inputs of current flake"      → {"action": "flake-inputs"}
+      "ls inside flake input X"           → {"action": "flake-inputs", "type": "ls", "query": "X"}
+      "read /nix/store/... file"          → {"action": "store", "type": "read", "query": "/nix/store/..."}
+      "ls /nix/store/... dir"             → {"action": "store", "type": "ls",   "query": "/nix/store/..."}
+
+    For package version *history* ("which commit shipped firefox 150?", "when was node 18 added?"),
+    use the separate `nix_versions` tool — it returns commit hashes, attribute paths, and dates.
 
     Notes:
       - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
@@ -221,8 +267,10 @@ async def nix(
       - For source=nix-dev, action=info returns the page markdown. The query may be a bare
         docname like "tutorials/nix-language", the URL printed by nix-dev search
         ("https://nix.dev/tutorials/nix-language"), or a rendered ".html" URL.
+      - action=info for packages matches on the exact attribute path first, then the exact pname.
+        If multiple packages share a pname (e.g. firefox / firefox-esr / firefox-mobile), the
+        canonical attribute wins and the response flags the disambiguation explicitly.
       - Omit parameters you don't need; do not pass empty strings for optional args.
-      - For package version history use the separate `nix_versions` tool.
     """
     # Limit validation: flake-inputs/store read allow up to 2000, others limited to 100
     if action == "flake-inputs" and type == "read":

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -160,14 +160,14 @@ _SERVER_INSTRUCTIONS = (
     "nix.dev, and Noogle. For package version *history* pair with `nix_versions`.\n"
     "- `nix_versions` — commit-accurate history from NixHub (which nixpkgs commit "
     "shipped version X, what attribute path, which platforms).\n\n"
-    "Common intents → calls:\n"
-    '  "is package X in channel Y?"         → nix(action=info, query=X, channel=Y)\n'
-    '  "which channels are available?"      → nix(action=channels)\n'
-    '  "search NixOS options for X"         → nix(action=search, query=X, type=options)\n'
-    '  "home-manager option for X"          → nix(action=search, source=home-manager, query=X)\n'
-    '  "does X have a binary cache?"        → nix(action=cache, query=X)\n'
-    '  "read /nix/store/<path>"             → nix(action=store, type=read, query=<path>)\n'
-    '  "which commit shipped X version Y?"  → nix_versions(package=X, version=Y)\n'
+    "Common intents → calls (copy the JSON shape exactly):\n"
+    '  "is package X in channel Y?"         → nix {"action":"info","query":"X","channel":"Y"}\n'
+    '  "which channels are available?"      → nix {"action":"channels"}\n'
+    '  "search NixOS options for X"         → nix {"action":"search","query":"X","type":"options"}\n'
+    '  "home-manager option for X"          → nix {"action":"search","source":"home-manager","query":"X"}\n'
+    '  "does X have a binary cache?"        → nix {"action":"cache","query":"X"}\n'
+    '  "read /nix/store/<path>"             → nix {"action":"store","type":"read","query":"/nix/store/<path>"}\n'
+    '  "which commit shipped X version Y?"  → nix_versions {"package":"X","version":"Y"}\n'
 )
 
 mcp = FastMCP("mcp-nixos", version=__version__, instructions=_SERVER_INSTRUCTIONS)

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -239,7 +239,8 @@ async def nix(
       "is package X in channel Y?"        → {"action": "info", "query": "X", "channel": "Y"}
       "search for package X"              → {"action": "search", "query": "X"}
       "which channels are available?"     → {"action": "channels"}
-      "which commit is channel X at?"     → {"action": "channels"}  (revision shown per channel)
+      "which commit did channel X index?" → {"action": "channels"}  (indexed commit shown when known;
+                                                                     branch HEAD otherwise — label matters)
       "search NixOS options for X"        → {"action": "search", "query": "X", "type": "options"}
       "get option details for X"          → {"action": "info", "query": "X", "type": "option"}
       "home-manager option for X"         → {"action": "search", "query": "X", "source": "home-manager"}

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -106,23 +106,29 @@ def _channel_to_branch(name: str, index: str, resolved: dict[str, str]) -> str:
     return ""
 
 
-def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> str:
-    """Resolve the current HEAD commit for a channel.
+def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> tuple[str, str]:
+    """Resolve a commit for a channel along with its provenance.
 
-    When the commit is embedded in the ES index name (older unstable indices),
-    use it directly. Otherwise do a best-effort GitHub API fetch keyed by
-    branch, with a short timeout and graceful degradation on failure or rate
-    limits.
+    Returns ``(sha, source)`` where ``source`` is:
+
+    - ``"indexed"`` — the commit is embedded in the ES index name, so the
+      package/option data returned for this channel was built from exactly
+      this commit. Safe to compare against with ``nix_versions``.
+    - ``"branch_head"`` — best-effort GitHub API fetch of the channel
+      branch's current HEAD. This may be a few commits ahead of the
+      published search index, so it is a *pointer* to the channel, not a
+      claim about the indexed data.
+    - ``""`` (empty) when nothing could be resolved.
     """
     embedded = _COMMIT_IN_INDEX.search(index)
     if embedded:
-        return embedded.group(1)
+        return embedded.group(1), "indexed"
 
     branch = _channel_to_branch(name, index, resolved)
     if not branch:
-        return ""
+        return "", ""
     if branch in _BRANCH_REVS:
-        return _BRANCH_REVS[branch]
+        return _BRANCH_REVS[branch], "branch_head"
 
     try:
         resp = requests.get(
@@ -132,11 +138,12 @@ def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> str:
         )
         if resp.status_code == 200:
             rev = resp.json().get("sha", "") or ""
-            _BRANCH_REVS[branch] = rev
-            return rev
+            if rev:
+                _BRANCH_REVS[branch] = rev
+                return rev, "branch_head"
     except requests.RequestException:
         pass
-    return ""
+    return "", ""
 
 
 def _list_channels() -> str:
@@ -160,17 +167,25 @@ def _list_channels() -> str:
                     label = f"* {name} (current: {parts[3]})"
             results.append(f"{label} -> {index}")
             results.append(f"  Status: {status} ({doc_count})")
-            rev = _channel_revision(name, index, configured)
-            if rev:
-                branch = _channel_to_branch(name, index, configured)
-                branch_note = f" ({branch})" if branch else ""
-                results.append(f"  Revision: {rev}{branch_note}")
+            rev, source = _channel_revision(name, index, configured)
+            branch = _channel_to_branch(name, index, configured)
+            if branch:
+                results.append(f"  Branch: {branch}")
+            if rev and source == "indexed":
+                # Exact commit the search index was built from — safe to
+                # compare package versions against.
+                results.append(f"  Revision (indexed): {rev}")
+            elif rev and source == "branch_head":
+                # Upstream branch HEAD; the search index for this channel
+                # may lag by a handful of commits.
+                results.append(f"  Branch HEAD: {rev} (upstream; may be ahead of indexed data)")
             results.append("")
 
         results.append(
-            "Note: 'stable' always points to current stable release. Revisions show the "
-            "nixpkgs HEAD commit for the channel's branch — use this to compare commit "
-            "hashes against a channel or pass to `nix_versions` for version history."
+            "Note: 'stable' always points to current stable release. "
+            "'Revision (indexed)' is the exact commit the search index was built from "
+            "(safe to compare against `nix_versions`). 'Branch HEAD' is the upstream "
+            "branch tip (useful as a pointer but may be ahead of indexed data)."
         )
         return "\n".join(results).strip()
     except Exception as e:

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -1,5 +1,6 @@
 """Base functionality shared across data sources."""
 
+import re
 from typing import Any
 
 import requests
@@ -13,6 +14,16 @@ from ..config import (
     APIError,
 )
 from ..utils import error, parse_html_options
+
+# Match the 40-char hex commit appended to unstable ES indices,
+# e.g. `nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc`.
+_COMMIT_IN_INDEX = re.compile(r"-([0-9a-f]{40})$")
+
+# Per-process cache for GitHub channel HEAD lookups. Persists for the
+# lifetime of the MCP server; populated lazily. Keys are nixpkgs branch names
+# (e.g. "nixos-unstable", "nixos-25.11"), so multiple channel aliases pointing
+# to the same branch share a single lookup.
+_BRANCH_REVS: dict[str, str] = {}
 
 # =============================================================================
 # Channel helpers
@@ -80,8 +91,56 @@ def es_query(index: str, query: dict[str, Any], size: int = 20) -> list[dict[str
 # =============================================================================
 
 
+def _channel_to_branch(name: str, index: str, resolved: dict[str, str]) -> str:
+    """Map a channel name to its nixpkgs branch for commit lookups."""
+    if "unstable" in name or "unstable" in index:
+        return "nixos-unstable"
+    if name in {"stable", "beta"}:
+        # Resolve to the release version indirectly via the ES index name.
+        parts = index.split("-")
+        if len(parts) >= 4 and re.match(r"^\d+\.\d+$", parts[3]):
+            return f"nixos-{parts[3]}"
+        return ""
+    if re.match(r"^\d+\.\d+$", name):
+        return f"nixos-{name}"
+    return ""
+
+
+def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> str:
+    """Resolve the current HEAD commit for a channel.
+
+    When the commit is embedded in the ES index name (older unstable indices),
+    use it directly. Otherwise do a best-effort GitHub API fetch keyed by
+    branch, with a short timeout and graceful degradation on failure or rate
+    limits.
+    """
+    embedded = _COMMIT_IN_INDEX.search(index)
+    if embedded:
+        return embedded.group(1)
+
+    branch = _channel_to_branch(name, index, resolved)
+    if not branch:
+        return ""
+    if branch in _BRANCH_REVS:
+        return _BRANCH_REVS[branch]
+
+    try:
+        resp = requests.get(
+            f"https://api.github.com/repos/NixOS/nixpkgs/commits/{branch}",
+            headers={"Accept": "application/vnd.github+json"},
+            timeout=4,
+        )
+        if resp.status_code == 200:
+            rev = resp.json().get("sha", "") or ""
+            _BRANCH_REVS[branch] = rev
+            return rev
+    except requests.RequestException:
+        pass
+    return ""
+
+
 def _list_channels() -> str:
-    """List available NixOS channels with status and document counts."""
+    """List available NixOS channels with status, document counts, and HEAD commit."""
     try:
         configured = get_channels()
         available = channel_cache.get_available()
@@ -101,9 +160,18 @@ def _list_channels() -> str:
                     label = f"* {name} (current: {parts[3]})"
             results.append(f"{label} -> {index}")
             results.append(f"  Status: {status} ({doc_count})")
+            rev = _channel_revision(name, index, configured)
+            if rev:
+                branch = _channel_to_branch(name, index, configured)
+                branch_note = f" ({branch})" if branch else ""
+                results.append(f"  Revision: {rev}{branch_note}")
             results.append("")
 
-        results.append("Note: 'stable' always points to current stable release.")
+        results.append(
+            "Note: 'stable' always points to current stable release. Revisions show the "
+            "nixpkgs HEAD commit for the channel's branch — use this to compare commit "
+            "hashes against a channel or pass to `nix_versions` for version history."
+        )
         return "\n".join(results).strip()
     except Exception as e:
         return error(str(e))

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -148,11 +148,15 @@ def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> tuple[
             timeout=4,
         )
         if resp.status_code == 200:
-            rev = resp.json().get("sha", "") or ""
+            data = resp.json()
+            rev = data.get("sha", "") if isinstance(data, dict) else ""
             if rev:
                 _BRANCH_REVS[branch] = (rev, now)
                 return rev, "branch_head"
-    except requests.RequestException:
+    except (requests.RequestException, ValueError):
+        # ValueError covers json decoding failures on a 200 with a non-JSON
+        # body (rare, but e.g. GitHub interstitials). Treat as a miss so the
+        # channels listing can still fall back to a stale cache or empty rev.
         pass
     # Fall back to a stale cached value if the refresh attempt failed —
     # better to surface last-known HEAD than nothing.

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -1,10 +1,12 @@
 """Base functionality shared across data sources."""
 
 import re
+import time
 from typing import Any
 
 import requests
 
+from .. import __version__
 from ..caches import channel_cache
 from ..config import (
     DARWIN_URL,
@@ -19,11 +21,15 @@ from ..utils import error, parse_html_options
 # e.g. `nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc`.
 _COMMIT_IN_INDEX = re.compile(r"-([0-9a-f]{40})$")
 
-# Per-process cache for GitHub channel HEAD lookups. Persists for the
-# lifetime of the MCP server; populated lazily. Keys are nixpkgs branch names
-# (e.g. "nixos-unstable", "nixos-25.11"), so multiple channel aliases pointing
-# to the same branch share a single lookup.
-_BRANCH_REVS: dict[str, str] = {}
+# Short per-process cache for GitHub branch HEAD lookups, keyed by nixpkgs
+# branch name. Entries expire after ~10 minutes so a long-running MCP
+# process does not keep reporting a stale HEAD after upstream advances
+# (see CodeRabbit review on PR #147). Channel aliases pointing to the
+# same branch share a single lookup.
+_BRANCH_REV_TTL = 600.0
+_BRANCH_REVS: dict[str, tuple[str, float]] = {}
+
+_GITHUB_USER_AGENT = f"mcp-nixos/{__version__}"
 
 # =============================================================================
 # Channel helpers
@@ -127,22 +133,31 @@ def _channel_revision(name: str, index: str, resolved: dict[str, str]) -> tuple[
     branch = _channel_to_branch(name, index, resolved)
     if not branch:
         return "", ""
-    if branch in _BRANCH_REVS:
-        return _BRANCH_REVS[branch], "branch_head"
+    cached = _BRANCH_REVS.get(branch)
+    now = time.monotonic()
+    if cached and (now - cached[1]) < _BRANCH_REV_TTL:
+        return cached[0], "branch_head"
 
     try:
         resp = requests.get(
             f"https://api.github.com/repos/NixOS/nixpkgs/commits/{branch}",
-            headers={"Accept": "application/vnd.github+json"},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": _GITHUB_USER_AGENT,
+            },
             timeout=4,
         )
         if resp.status_code == 200:
             rev = resp.json().get("sha", "") or ""
             if rev:
-                _BRANCH_REVS[branch] = rev
+                _BRANCH_REVS[branch] = (rev, now)
                 return rev, "branch_head"
     except requests.RequestException:
         pass
+    # Fall back to a stale cached value if the refresh attempt failed —
+    # better to surface last-known HEAD than nothing.
+    if cached:
+        return cached[0], "branch_head"
     return "", ""
 
 
@@ -185,7 +200,9 @@ def _list_channels() -> str:
             "Note: 'stable' always points to current stable release. "
             "'Revision (indexed)' is the exact commit the search index was built from "
             "(safe to compare against `nix_versions`). 'Branch HEAD' is the upstream "
-            "branch tip (useful as a pointer but may be ahead of indexed data)."
+            "branch tip, fetched best-effort from GitHub and cached for up to "
+            "10 minutes per process — it may be a few commits ahead of the "
+            "indexed data or a few minutes stale from the upstream ref."
         )
         return "\n".join(results).strip()
     except Exception as e:

--- a/mcp_nixos/sources/nixos.py
+++ b/mcp_nixos/sources/nixos.py
@@ -1,6 +1,7 @@
 """NixOS packages and options source."""
 
 import re
+from typing import Any
 
 from ..utils import error
 from .base import es_query, get_channel_suggestions, get_channels
@@ -108,14 +109,36 @@ def _info_nixos(name: str, info_type: str, channel: str) -> str:
         return error(f"Invalid channel '{channel}'. {get_channel_suggestions(channel)}")
 
     try:
-        field = "package_pname" if info_type == "package" else "option_name"
-        query = {"bool": {"must": [{"term": {"type": info_type}}, {"term": {field: name}}]}}
-        hits = es_query(channels[channel], query, 1)
-
-        # For packages, fall back to searching by attribute name (e.g. kdePackages.qt6ct)
-        if not hits and info_type == "package":
+        if info_type == "package":
+            # Priority 1: exact attribute path match — one attr maps to one package, so
+            # this is deterministic. Handles dotted names (kdePackages.qt6ct) and
+            # disambiguates between packages that share a pname (firefox, firefox-esr,
+            # firefox-mobile all have pname="firefox"). See GH #146.
             attr_query = {"bool": {"must": [{"term": {"type": "package"}}, {"term": {"package_attr_name": name}}]}}
             hits = es_query(channels[channel], attr_query, 1)
+            matched_via = "attribute" if hits else ""
+
+            pname_candidates: list[dict[str, Any]] = []
+            if not hits:
+                # Priority 2: pname match. Fetch up to 5 so we can detect ambiguity
+                # (multiple attrs sharing the same pname) and pick the canonical one.
+                pname_query = {"bool": {"must": [{"term": {"type": "package"}}, {"term": {"package_pname": name}}]}}
+                pname_candidates = es_query(channels[channel], pname_query, 5)
+                if pname_candidates:
+                    # Prefer the canonical entry (attr == pname) when it exists
+                    canonical = [
+                        h
+                        for h in pname_candidates
+                        if h.get("_source", {}).get("package_attr_name") == h.get("_source", {}).get("package_pname")
+                    ]
+                    chosen = canonical[0] if canonical else pname_candidates[0]
+                    hits = [chosen]
+                    matched_via = "pname"
+        else:
+            query = {"bool": {"must": [{"term": {"type": "option"}}, {"term": {"option_name": name}}]}}
+            hits = es_query(channels[channel], query, 1)
+            matched_via = "exact" if hits else ""
+            pname_candidates = []
 
         if not hits:
             return error(f"{info_type.capitalize()} '{name}' not found", "NOT_FOUND")
@@ -139,6 +162,34 @@ def _info_nixos(name: str, info_type: str, channel: str) -> str:
             licenses = src.get("package_license_set", [])
             if licenses:
                 info.append(f"License: {', '.join(licenses)}")
+            if matched_via == "pname" and len(pname_candidates) > 1:
+                # Flag ambiguity explicitly so callers don't silently act on the wrong
+                # package. Name the alternatives so the caller can retry with the exact
+                # attribute path.
+                alternatives = sorted(
+                    {
+                        h.get("_source", {}).get("package_attr_name", "")
+                        for h in pname_candidates
+                        if h.get("_source", {}).get("package_attr_name")
+                    }
+                )
+                chosen_attr = attr_name or pname
+                others = [a for a in alternatives if a != chosen_attr]
+                if others:
+                    picked_canonical = any(
+                        h.get("_source", {}).get("package_attr_name")
+                        == h.get("_source", {}).get("package_pname")
+                        == name
+                        for h in pname_candidates
+                    )
+                    chosen_label = "the canonical entry" if picked_canonical else "a representative entry"
+                    info.append("")
+                    info.append(
+                        f"Note: '{name}' is a pname shared by multiple packages. Returned "
+                        f"{chosen_label} ({chosen_attr}). Other attributes with the same "
+                        f"pname: {', '.join(others)}. Pass an exact attribute to "
+                        f"disambiguate (e.g. action=info, query={others[0]!r})."
+                    )
             return "\n".join(info)
         else:
             info = [f"Option: {src.get('option_name', '')}"]

--- a/mcp_nixos/sources/nixos.py
+++ b/mcp_nixos/sources/nixos.py
@@ -126,13 +126,25 @@ def _info_nixos(name: str, info_type: str, channel: str) -> str:
                 pname_query = {"bool": {"must": [{"term": {"type": "package"}}, {"term": {"package_pname": name}}]}}
                 pname_candidates = es_query(channels[channel], pname_query, 5)
                 if pname_candidates:
-                    # Prefer the canonical entry (attr == pname) when it exists
+                    # Prefer the canonical entry (attr == pname). When none
+                    # exists, sort by attribute path so the tie-break is
+                    # deterministic across requests — ES does not guarantee
+                    # a stable order for equal-score term matches.
                     canonical = [
                         h
                         for h in pname_candidates
                         if h.get("_source", {}).get("package_attr_name") == h.get("_source", {}).get("package_pname")
                     ]
-                    chosen = canonical[0] if canonical else pname_candidates[0]
+                    if canonical:
+                        chosen = canonical[0]
+                    else:
+                        chosen = sorted(
+                            pname_candidates,
+                            key=lambda h: (
+                                h.get("_source", {}).get("package_attr_name", ""),
+                                h.get("_source", {}).get("package_pname", ""),
+                            ),
+                        )[0]
                     hits = [chosen]
                     matched_via = "pname"
         else:

--- a/mcp_nixos/sources/nixos.py
+++ b/mcp_nixos/sources/nixos.py
@@ -1,5 +1,6 @@
 """NixOS packages and options source."""
 
+import json
 import re
 from typing import Any
 
@@ -183,12 +184,13 @@ def _info_nixos(name: str, info_type: str, channel: str) -> str:
                         for h in pname_candidates
                     )
                     chosen_label = "the canonical entry" if picked_canonical else "a representative entry"
+                    retry_call = json.dumps({"action": "info", "query": others[0], "channel": channel})
                     info.append("")
                     info.append(
                         f"Note: '{name}' is a pname shared by multiple packages. Returned "
                         f"{chosen_label} ({chosen_attr}). Other attributes with the same "
                         f"pname: {', '.join(others)}. Pass an exact attribute to "
-                        f"disambiguate (e.g. action=info, query={others[0]!r})."
+                        f"disambiguate, e.g. {retry_call}."
                     )
             return "\n".join(info)
         else:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -530,6 +530,35 @@ class TestInfoMatchPriority:
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")
     @pytest.mark.asyncio
+    async def test_info_ambiguity_tiebreak_is_deterministic(self, mock_channels, mock_es):
+        """When no canonical exists, the chosen attr must be deterministic across ES orderings."""
+        from mcp_nixos.sources.nixos import _info_nixos
+
+        mock_channels.return_value = {"unstable": "nixos-unstable"}
+
+        def candidates(order: list[str]) -> list[dict]:
+            return [
+                {"_source": {"package_pname": "chicken-srfi", "package_attr_name": a, "package_pversion": "1"}}
+                for a in order
+            ]
+
+        # ES returns the hits in one order the first time, reversed the second.
+        # The tie-break must select the same attribute regardless.
+        mock_es.side_effect = [
+            [],
+            candidates(["chickenPackages_5.chickenEggs.srfi-2", "chickenPackages_5.chickenEggs.srfi-1"]),
+            [],
+            candidates(["chickenPackages_5.chickenEggs.srfi-1", "chickenPackages_5.chickenEggs.srfi-2"]),
+        ]
+        r1 = _info_nixos("chicken-srfi", "package", "unstable")
+        r2 = _info_nixos("chicken-srfi", "package", "unstable")
+        # Both calls must agree on the chosen attribute (alphabetically first).
+        assert "Attribute: chickenPackages_5.chickenEggs.srfi-1" in r1
+        assert "Attribute: chickenPackages_5.chickenEggs.srfi-1" in r2
+
+    @patch("mcp_nixos.sources.nixos.es_query")
+    @patch("mcp_nixos.sources.nixos.get_channels")
+    @pytest.mark.asyncio
     async def test_info_no_ambiguity_note_for_single_pname_hit(self, mock_channels, mock_es):
         """A single pname hit with no attr match must not emit the disambiguation note."""
         from mcp_nixos.sources.nixos import _info_nixos
@@ -647,6 +676,33 @@ class TestChannelRevisions:
             assert source == "branch_head"
             call_kwargs = mock_get.call_args.kwargs
             assert call_kwargs["headers"]["User-Agent"].startswith("mcp-nixos/")
+        finally:
+            base_mod._BRANCH_REVS.clear()
+
+    def test_branch_rev_invalid_json_response_falls_back(self):
+        """A 200 with a non-JSON body must be treated as a miss, not crash the listing."""
+        import time
+        from unittest.mock import MagicMock, patch
+
+        from mcp_nixos.sources import base as base_mod
+
+        base_mod._BRANCH_REVS.clear()
+        # Prior stale cache entry — we should return it on the fallback path.
+        base_mod._BRANCH_REVS["nixos-25.11"] = (
+            "ddddddddddddddddddddddddddddddddddddddd0",
+            time.monotonic() - (base_mod._BRANCH_REV_TTL * 10),
+        )
+        try:
+            fake_response = MagicMock()
+            fake_response.status_code = 200
+            fake_response.json.side_effect = ValueError("not json")
+            with patch("mcp_nixos.sources.base.requests.get", return_value=fake_response):
+                rev, source = base_mod._channel_revision(
+                    "25.11", "latest-46-nixos-25.11", {"25.11": "latest-46-nixos-25.11"}
+                )
+            # Must not raise; falls back to stale cached value.
+            assert rev == "ddddddddddddddddddddddddddddddddddddddd0"
+            assert source == "branch_head"
         finally:
             base_mod._BRANCH_REVS.clear()
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -445,6 +445,160 @@ class TestNixToolChannels:
         mock_list.assert_called_once()
 
 
+@pytest.mark.unit
+class TestInfoMatchPriority:
+    """Regression tests for GitHub #146.
+
+    action=info must prefer exact attribute match over pname match, and must
+    explicitly signal pname-based disambiguation when a query resolves to one
+    of several packages sharing a pname.
+    """
+
+    @patch("mcp_nixos.sources.nixos.es_query")
+    @patch("mcp_nixos.sources.nixos.get_channels")
+    @pytest.mark.asyncio
+    async def test_info_prefers_attr_match_over_pname(self, mock_channels, mock_es):
+        """Exact attr=firefox must win over the first pname=firefox candidate.
+
+        Before #146, pname matched first with size:1, which meant ES could
+        arbitrarily return firefox-esr for `info firefox`. Attr-first makes
+        the canonical package deterministic.
+        """
+        from mcp_nixos.sources.nixos import _info_nixos
+
+        mock_channels.return_value = {"unstable": "nixos-unstable"}
+        mock_es.return_value = [
+            {
+                "_source": {
+                    "package_pname": "firefox",
+                    "package_attr_name": "firefox",
+                    "package_pversion": "149.0.2",
+                    "package_description": "Web browser",
+                }
+            }
+        ]
+
+        result = _info_nixos("firefox", "package", "unstable")
+
+        first_query = mock_es.call_args_list[0][0][1]
+        must_terms = [c for c in first_query["bool"]["must"] if "term" in c]
+        assert any("package_attr_name" in c["term"] for c in must_terms), (
+            "First ES call must be an attribute-path lookup, not a pname lookup"
+        )
+        assert "firefox-esr" not in result
+        assert "Package: firefox" in result
+
+    @patch("mcp_nixos.sources.nixos.es_query")
+    @patch("mcp_nixos.sources.nixos.get_channels")
+    @pytest.mark.asyncio
+    async def test_info_signals_pname_ambiguity(self, mock_channels, mock_es):
+        """When only a pname match is possible and multiple attrs share it, flag it."""
+        from mcp_nixos.sources.nixos import _info_nixos
+
+        mock_channels.return_value = {"unstable": "nixos-unstable"}
+        mock_es.side_effect = [
+            [],  # attr lookup: miss
+            [
+                {
+                    "_source": {
+                        "package_pname": "chicken-srfi",
+                        "package_attr_name": "chickenPackages_5.chickenEggs.srfi-1",
+                        "package_pversion": "1",
+                    }
+                },
+                {
+                    "_source": {
+                        "package_pname": "chicken-srfi",
+                        "package_attr_name": "chickenPackages_5.chickenEggs.srfi-2",
+                        "package_pversion": "2",
+                    }
+                },
+            ],
+        ]
+
+        result = _info_nixos("chicken-srfi", "package", "unstable")
+
+        assert "pname shared by multiple packages" in result
+        assert "chickenPackages_5.chickenEggs.srfi-1" in result
+        assert "chickenPackages_5.chickenEggs.srfi-2" in result
+        assert "disambiguate" in result
+
+    @patch("mcp_nixos.sources.nixos.es_query")
+    @patch("mcp_nixos.sources.nixos.get_channels")
+    @pytest.mark.asyncio
+    async def test_info_no_ambiguity_note_for_single_pname_hit(self, mock_channels, mock_es):
+        """A single pname hit with no attr match must not emit the disambiguation note."""
+        from mcp_nixos.sources.nixos import _info_nixos
+
+        mock_channels.return_value = {"unstable": "nixos-unstable"}
+        mock_es.side_effect = [
+            [],
+            [
+                {
+                    "_source": {
+                        "package_pname": "qt6ct",
+                        "package_attr_name": "kdePackages.qt6ct",
+                        "package_pversion": "0.11",
+                    }
+                }
+            ],
+        ]
+
+        result = _info_nixos("qt6ct", "package", "unstable")
+        assert "pname shared by multiple packages" not in result
+        assert "kdePackages.qt6ct" in result
+
+
+@pytest.mark.unit
+class TestChannelRevisions:
+    """GitHub #146: action=channels surfaces nixpkgs HEAD commit per channel."""
+
+    def test_commit_extracted_from_unstable_index_name(self):
+        """When the ES index name embeds a 40-char hex commit, use it directly."""
+        from mcp_nixos.sources.base import _channel_revision
+
+        rev = _channel_revision(
+            "unstable",
+            "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+            {"unstable": "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc"},
+        )
+        assert rev == "b12141ef619e0a9c1c84dc8c684040326f27cdcc"
+
+    def test_list_channels_renders_revision_line(self):
+        """_list_channels output must include a Revision line for channels we can resolve."""
+        from unittest.mock import patch
+
+        from mcp_nixos.sources.base import _list_channels
+
+        fake_channels = {
+            "unstable": "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        }
+        with (
+            patch("mcp_nixos.sources.base.get_channels", return_value=fake_channels),
+            patch("mcp_nixos.sources.base.channel_cache") as mock_cache,
+        ):
+            mock_cache.using_fallback = False
+            mock_cache.get_available.return_value = {
+                "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc": "1,000 documents"
+            }
+            result = _list_channels()
+
+        assert "Revision: b12141ef619e0a9c1c84dc8c684040326f27cdcc" in result
+        assert "nixos-unstable" in result
+
+
+@pytest.mark.unit
+class TestServerInstructions:
+    """GitHub #146: the MCP server must surface instructions prose to clients."""
+
+    def test_server_has_instructions(self):
+        from mcp_nixos.server import mcp
+
+        instructions = getattr(mcp, "instructions", "") or ""
+        assert "nixpkgs" in instructions.lower()
+        assert "nix_versions" in instructions
+
+
 class TestNixVersionsValidation:
     """Test input validation for nix_versions tool."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -522,6 +522,10 @@ class TestInfoMatchPriority:
         assert "chickenPackages_5.chickenEggs.srfi-1" in result
         assert "chickenPackages_5.chickenEggs.srfi-2" in result
         assert "disambiguate" in result
+        # The retry hint must be a copy-pasteable JSON object, not a pseudo-call.
+        # The hint picks one of the "other" attrs (not the chosen one) to disambiguate to.
+        assert '"action": "info"' in result
+        assert '"query": "chickenPackages_5.chickenEggs.srfi-2"' in result
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")
@@ -592,12 +596,13 @@ class TestChannelRevisions:
 
     def test_list_channels_labels_branch_head_when_not_indexed(self):
         """For release channels we can only look up branch HEAD — label it honestly."""
+        import time
         from unittest.mock import patch
 
         from mcp_nixos.sources.base import _BRANCH_REVS, _list_channels
 
         _BRANCH_REVS.clear()
-        _BRANCH_REVS["nixos-25.11"] = "abc1234abc1234abc1234abc1234abc1234abcd"
+        _BRANCH_REVS["nixos-25.11"] = ("abc1234abc1234abc1234abc1234abc1234abcd", time.monotonic())
         fake_channels = {"25.11": "latest-46-nixos-25.11"}
         try:
             with (
@@ -617,6 +622,50 @@ class TestChannelRevisions:
         # Must NOT imply this is the indexed commit in the channel entry.
         assert "Revision (indexed)" not in channels_block
 
+    def test_branch_rev_cache_respects_ttl(self):
+        """A stale entry past the TTL must trigger a re-fetch (CodeRabbit/Copilot review)."""
+        from unittest.mock import MagicMock, patch
+
+        from mcp_nixos.sources import base as base_mod
+
+        base_mod._BRANCH_REVS.clear()
+        # Seed a stale entry
+        base_mod._BRANCH_REVS["nixos-25.11"] = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0.0)
+        try:
+            fake_response = MagicMock()
+            fake_response.status_code = 200
+            fake_response.json.return_value = {"sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+            with patch("mcp_nixos.sources.base.requests.get", return_value=fake_response) as mock_get:
+                rev, source = base_mod._channel_revision(
+                    "25.11", "latest-46-nixos-25.11", {"25.11": "latest-46-nixos-25.11"}
+                )
+            assert rev == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            assert source == "branch_head"
+            call_kwargs = mock_get.call_args.kwargs
+            assert call_kwargs["headers"]["User-Agent"].startswith("mcp-nixos/")
+        finally:
+            base_mod._BRANCH_REVS.clear()
+
+    def test_branch_rev_cache_serves_within_ttl(self):
+        """A fresh cached entry must NOT trigger a network call."""
+        import time
+        from unittest.mock import patch
+
+        from mcp_nixos.sources import base as base_mod
+
+        base_mod._BRANCH_REVS.clear()
+        base_mod._BRANCH_REVS["nixos-25.11"] = ("cccccccccccccccccccccccccccccccccccccccc", time.monotonic())
+        try:
+            with patch("mcp_nixos.sources.base.requests.get") as mock_get:
+                rev, source = base_mod._channel_revision(
+                    "25.11", "latest-46-nixos-25.11", {"25.11": "latest-46-nixos-25.11"}
+                )
+            assert rev == "cccccccccccccccccccccccccccccccccccccccc"
+            assert source == "branch_head"
+            mock_get.assert_not_called()
+        finally:
+            base_mod._BRANCH_REVS.clear()
+
 
 @pytest.mark.unit
 class TestServerInstructions:
@@ -628,6 +677,18 @@ class TestServerInstructions:
         instructions = getattr(mcp, "instructions", "") or ""
         assert "nixpkgs" in instructions.lower()
         assert "nix_versions" in instructions
+
+    def test_server_instructions_use_json_call_shapes(self):
+        """Recipe examples must match the JSON-object shape models actually send."""
+        from mcp_nixos.server import mcp
+
+        instructions = getattr(mcp, "instructions", "") or ""
+        # The quoted JSON object form is what hosts serialize — the bare
+        # `nix(action=...)` pseudo-call form would teach models a syntax that
+        # does not work over MCP.
+        assert '{"action":"info","query":"X","channel":"Y"}' in instructions
+        assert '{"action":"channels"}' in instructions
+        assert "action=" not in instructions.replace('"action":', "")
 
 
 class TestNixVersionsValidation:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -554,18 +554,19 @@ class TestChannelRevisions:
     """GitHub #146: action=channels surfaces nixpkgs HEAD commit per channel."""
 
     def test_commit_extracted_from_unstable_index_name(self):
-        """When the ES index name embeds a 40-char hex commit, use it directly."""
+        """When the ES index name embeds a 40-char hex commit, it is reported as indexed."""
         from mcp_nixos.sources.base import _channel_revision
 
-        rev = _channel_revision(
+        rev, source = _channel_revision(
             "unstable",
             "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc",
             {"unstable": "nixos-46-unstable-b12141ef619e0a9c1c84dc8c684040326f27cdcc"},
         )
         assert rev == "b12141ef619e0a9c1c84dc8c684040326f27cdcc"
+        assert source == "indexed"
 
-    def test_list_channels_renders_revision_line(self):
-        """_list_channels output must include a Revision line for channels we can resolve."""
+    def test_list_channels_labels_indexed_revision(self):
+        """When the SHA is embedded in the index, label it as 'Revision (indexed)'."""
         from unittest.mock import patch
 
         from mcp_nixos.sources.base import _list_channels
@@ -583,8 +584,38 @@ class TestChannelRevisions:
             }
             result = _list_channels()
 
-        assert "Revision: b12141ef619e0a9c1c84dc8c684040326f27cdcc" in result
-        assert "nixos-unstable" in result
+        channels_block = result.split("Note:", 1)[0]
+        assert "Revision (indexed): b12141ef619e0a9c1c84dc8c684040326f27cdcc" in channels_block
+        assert "Branch: nixos-unstable" in channels_block
+        # Must NOT mislabel an indexed commit as a branch HEAD in the channel entry.
+        assert "Branch HEAD" not in channels_block
+
+    def test_list_channels_labels_branch_head_when_not_indexed(self):
+        """For release channels we can only look up branch HEAD — label it honestly."""
+        from unittest.mock import patch
+
+        from mcp_nixos.sources.base import _BRANCH_REVS, _list_channels
+
+        _BRANCH_REVS.clear()
+        _BRANCH_REVS["nixos-25.11"] = "abc1234abc1234abc1234abc1234abc1234abcd"
+        fake_channels = {"25.11": "latest-46-nixos-25.11"}
+        try:
+            with (
+                patch("mcp_nixos.sources.base.get_channels", return_value=fake_channels),
+                patch("mcp_nixos.sources.base.channel_cache") as mock_cache,
+            ):
+                mock_cache.using_fallback = False
+                mock_cache.get_available.return_value = {"latest-46-nixos-25.11": "100,000 documents"}
+                result = _list_channels()
+        finally:
+            _BRANCH_REVS.clear()
+
+        channels_block = result.split("Note:", 1)[0]
+        assert "Branch: nixos-25.11" in channels_block
+        assert "Branch HEAD: abc1234abc1234abc1234abc1234abc1234abcd" in channels_block
+        assert "may be ahead of indexed data" in channels_block
+        # Must NOT imply this is the indexed commit in the channel entry.
+        assert "Revision (indexed)" not in channels_block
 
 
 @pytest.mark.unit

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -624,13 +624,17 @@ class TestChannelRevisions:
 
     def test_branch_rev_cache_respects_ttl(self):
         """A stale entry past the TTL must trigger a re-fetch (CodeRabbit/Copilot review)."""
+        import time
         from unittest.mock import MagicMock, patch
 
         from mcp_nixos.sources import base as base_mod
 
         base_mod._BRANCH_REVS.clear()
-        # Seed a stale entry
-        base_mod._BRANCH_REVS["nixos-25.11"] = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0.0)
+        # Seed a stale entry: timestamp is well past the TTL relative to now.
+        # Using a large negative offset rather than 0.0 so the test works in
+        # fresh processes where time.monotonic() starts near zero.
+        stale_ts = time.monotonic() - (base_mod._BRANCH_REV_TTL * 10)
+        base_mod._BRANCH_REVS["nixos-25.11"] = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", stale_ts)
         try:
             fake_response = MagicMock()
             fake_response.status_code = 200


### PR DESCRIPTION
## Summary

Fixes #146. Makes models reach for this MCP server first on Nix-flavored questions instead of falling back to Bash / `gh api` / scraping search.nixos.org, and makes `action=info` deterministic.

- **Server-level `instructions`** string passed to the FastMCP constructor so the MCP `InitializeResult` carries a value-proposition and intent→call recipe block (what hosts render alongside tool schemas).
- **INTENTS → CALLS recipe block** in the `nix` tool docstring, mapping real user phrasings to concrete JSON call shapes, plus an explicit cross-reference to `nix_versions` for history lookups.
- **Fix silent fuzzy match in `action=info`** for packages: match by exact attribute path first, then fall back to pname. When multiple attrs share a pname (`firefox` / `firefox-esr` / `firefox-mobile`), prefer the canonical entry and explicitly flag the disambiguation in the response. Before this change, `{"action": "info", "query": "firefox"}` could arbitrarily return `firefox-esr`.
- **Per-channel nixpkgs HEAD revision** in `action=channels`: commit extracted from the ES index name when embedded (older unstable indices), otherwise a best-effort GitHub API fetch cached per branch across the process lifetime. Lets models answer "which channel contains commit X" without leaving the MCP.

## Test plan

- [x] `nix develop -c format` — clean
- [x] `nix develop -c lint` — clean
- [x] `nix develop -c typecheck` — clean
- [x] `nix develop -c run-tests` — **342 passed** (6 new unit tests added: attr-first priority, ambiguity signaling, single-hit pname cleanliness, commit extraction from index names, mocked channels-with-revision render, server instructions populated)
- [x] Live verification against `search.nixos.org`: `firefox`, `firefox-esr`, `kdePackages.qt6ct`, `chicken-srfi` (ambiguity note), channels output with revisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now provides explicit startup instructions (domains routed to the server) mapping intents to exact JSON tool-call shapes, including new intents like stats, flake-inputs, and /nix/store listings.
  * Channel listings show derived branch vs indexed-commit provenance and note caching/lag behavior.
  * Package lookups prioritize exact attribute matches and append disambiguation guidance when multiple attrs share a name; option lookups use exact-match queries.

* **Tests**
  * Added unit tests for package disambiguation, channel labeling, cache/TTL behavior, and server instruction examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->