### PR TITLE
test(store): fix flaky "Error" not-in-result assertions

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -138,7 +138,7 @@ class TestStoreLsRealPath:
             pytest.skip("/nix/store not available or empty")
 
         result = await _store_ls(store_dir, 500)
-        assert "Error" not in result
+        assert not result.startswith("Error (")
         assert store_dir in result
         # `_pick_real_store_dir` may pick a valid but empty store output
         # (nixpkgs produces empty directories for some derivations). Accept
@@ -164,7 +164,7 @@ class TestStoreLsRealPath:
             pytest.skip("no /nix/store entry with 2+ children found")
 
         result = await _store_ls(big_dir, 1)
-        assert "Error" not in result
+        assert not result.startswith("Error (")
         assert "showing 1 of" in result
         # Exactly one entry line (two-space indent) should follow the header/blank line.
         entry_lines = [ln for ln in result.splitlines() if ln.startswith("  ")]
@@ -261,7 +261,7 @@ class TestStoreReadTextFile:
             pytest.skip("no small text file found in first store entry")
 
         result = await _store_read(text_file, 2000)
-        assert "Error" not in result
+        assert not result.startswith("Error (")
         assert f"File: {text_file}" in result
         assert "Size:" in result
 
@@ -302,7 +302,7 @@ class TestStoreReadTextFile:
             pytest.skip("no multi-line text file found in first store entry")
 
         result = await _store_read(candidate, 1)
-        assert "Error" not in result
+        assert not result.startswith("Error (")
         assert "Showing 1 of" in result
 
 


### PR DESCRIPTION
Four happy-path tests asserted `"Error" not in result` to confirm _store_read/_store_ls didn't return an error. This matched the entire response string including file content, so any text file containing the word "Error" (e.g. Python source with exception class names) would fail the assertion on a perfectly successful read.

Fix: check `not result.startswith("Error (")` instead, which matches the exact format of the error() helper (`"Error (CODE): message"`) without touching file content.

Observed on Hydra: https://hydra.nixos.org/build/328923381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved validation assertions for store operations to more precisely detect successful responses and ensure accurate error detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utensils/mcp-nixos/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->