### PR TITLE
chore: switch direnv to nix-direnv for cached devshell loads

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,10 @@
+# Bootstrap nix-direnv if not installed system-wide. Pinned for reproducibility.
+# nix-direnv caches the evaluated devshell so we only re-evaluate when an input
+# changes — much faster than the direnv-builtin `use flake`.
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
+  source_url \
+    "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.1/direnvrc" \
+    "sha256-p+fzQdrms/hDa7g+soShAybJNo4bN4SIAeSfqNKgD5I="
+fi
+
 use flake


### PR DESCRIPTION
## Summary
- Bootstraps **nix-direnv 3.1.1** in `.envrc` via `source_url` with a pinned SRI hash, falling back to the direnv-builtin only when nothing newer is already loaded globally.
- Replaces the direnv-builtin `use flake`, which re-evaluated the flake on every shell entry.
- nix-direnv auto-watches every file Nix reads during evaluation (`flake.nix`, `flake.lock`, `nix/*.nix`), so no explicit `watch_file` entries are needed.

## Why
The previous `.envrc` was a single line: `use flake`. That works, but the direnv-builtin re-runs `nix print-dev-env` on every shell entry — multi-second pauses each `cd` into the repo. nix-direnv caches the resolved profile under `.direnv/` and only re-evaluates when an input changes.

Measured on a clean clone:
- Cold load (first time, populates the cache): ~1m52s
- Warm load (every subsequent entry): ~0.2s

## Test plan
- [x] `direnv allow` succeeds against the new `.envrc`
- [x] First load builds and caches the dev profile (`mcp-nixos` / `python` on PATH)
- [x] Warm reloads complete in ~200ms
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment setup to ensure proper initialization of required dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utensils/mcp-nixos/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->