### PR TITLE
fix(caches): discover channels via _cat/aliases, pick max generation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,9 +55,9 @@ return json.dumps({"name": name, "version": version})
 
 ### 2. Channel Resolution System
 
-Channels are dynamically discovered on startup by probing Elasticsearch generations (43-46) across versions (unstable, 25.05, 25.11, etc.). The `ChannelCache` class maintains this state.
+Channels are dynamically discovered on startup via Elasticsearch's `_cat/aliases` endpoint, which lists every `latest-<gen>-nixos-<channel>` alias currently live on search.nixos.org. The `ChannelCache` class picks the highest generation per channel (so `unstable` always resolves to the freshest index, even mid-rollover) and maintains this state.
 
-- `"stable"` always maps to current stable release (e.g., "latest-44-nixos-25.11")
+- `"stable"` always maps to current stable release (e.g., "latest-48-nixos-25.11")
 - `FALLBACK_CHANNELS` dict used when API discovery fails
 - Override via `ELASTICSEARCH_URL` environment variable for local testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,7 +57,7 @@ return json.dumps({"name": name, "version": version})
 
 Channels are dynamically discovered on startup via Elasticsearch's `_cat/aliases` endpoint, which lists every `latest-<gen>-nixos-<channel>` alias currently live on search.nixos.org. The `ChannelCache` class picks the highest generation per channel (so `unstable` always resolves to the freshest index, even mid-rollover) and maintains this state.
 
-- `"stable"` always maps to current stable release (e.g., "latest-48-nixos-25.11")
+- `"stable"` always maps to current stable release (e.g., `latest-<gen>-nixos-<version>`)
 - `FALLBACK_CHANNELS` dict used when API discovery fails
 - Override via `ELASTICSEARCH_URL` environment variable for local testing
 

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -20,6 +20,13 @@ from .config import (
 class ChannelCache:
     """Cache for discovered channels and resolved mappings."""
 
+    # Matches `latest-<gen>-nixos-<channel>` aliases, where <channel> is either
+    # the string "unstable" or a release like "25.11". The generation captured
+    # in group 1 is what disambiguates rollovers — when Hydra publishes a new
+    # index for a channel it increments the generation and atomically retargets
+    # the alias, so the highest generation is always the freshest data.
+    _ALIAS_RE = re.compile(r"^latest-(\d+)-nixos-(unstable|\d+\.\d+)$")
+
     def __init__(self) -> None:
         self.available_channels: dict[str, str] | None = None
         self.resolved_channels: dict[str, str] | None = None
@@ -36,25 +43,48 @@ class ChannelCache:
         return self.resolved_channels if self.resolved_channels is not None else {}
 
     def _discover_available_channels(self) -> dict[str, str]:
-        generations = [43, 44, 45, 46]
-        versions = ["unstable", "25.05", "25.11", "26.05", "26.11"]
-        available = {}
-        for gen in generations:
-            for version in versions:
-                pattern = f"latest-{gen}-nixos-{version}"
-                try:
-                    resp = requests.post(
-                        f"{NIXOS_API}/{pattern}/_count",
-                        json={"query": {"match_all": {}}},
-                        auth=NIXOS_AUTH,
-                        timeout=10,
-                    )
-                    if resp.status_code == 200:
-                        count = resp.json().get("count", 0)
-                        if count > 0:
-                            available[pattern] = f"{count:,} documents"
-                except Exception:
-                    continue
+        """Discover live `latest-*-nixos-*` aliases via Elasticsearch.
+
+        Replaces a hardcoded `[43..46]` probe loop with a single
+        `_cat/aliases` call, so newly published channel generations
+        (e.g. `latest-48-nixos-unstable` after Hydra rolls forward) are
+        picked up automatically instead of bit-rotting in the source.
+        """
+        available: dict[str, str] = {}
+        try:
+            resp = requests.get(
+                f"{NIXOS_API}/_cat/aliases?format=json",
+                auth=NIXOS_AUTH,
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                return available
+            entries = resp.json()
+            if not isinstance(entries, list):
+                return available
+        except Exception:
+            return available
+
+        aliases = [
+            entry["alias"]
+            for entry in entries
+            if isinstance(entry, dict) and self._ALIAS_RE.match(str(entry.get("alias", "")))
+        ]
+
+        for alias in aliases:
+            try:
+                count_resp = requests.post(
+                    f"{NIXOS_API}/{alias}/_count",
+                    json={"query": {"match_all": {}}},
+                    auth=NIXOS_AUTH,
+                    timeout=10,
+                )
+                if count_resp.status_code == 200:
+                    count = count_resp.json().get("count", 0)
+                    if count > 0:
+                        available[alias] = f"{count:,} documents"
+            except Exception:
+                continue
         return available
 
     def _resolve_channels(self) -> dict[str, str]:
@@ -63,42 +93,38 @@ class ChannelCache:
             self.using_fallback = True
             return FALLBACK_CHANNELS.copy()
 
-        resolved = {}
-        unstable_pattern = None
+        # Bucket aliases by channel name ("unstable", "25.11", ...) and
+        # remember each candidate's generation so we can pick the maximum
+        # per channel. The previous implementation picked the *first*
+        # unstable match in dict-insertion order, which yielded the lowest
+        # generation when multiple unstable indices were live.
+        by_channel: dict[str, list[tuple[int, str]]] = {}
         for pattern in available:
-            if "unstable" in pattern:
-                unstable_pattern = pattern
-                break
-        if unstable_pattern:
-            resolved["unstable"] = unstable_pattern
+            match = self._ALIAS_RE.match(pattern)
+            if not match:
+                continue
+            gen = int(match.group(1))
+            channel = match.group(2)
+            by_channel.setdefault(channel, []).append((gen, pattern))
 
-        stable_candidates = []
-        for pattern, count_str in available.items():
-            if "unstable" not in pattern:
-                parts = pattern.split("-")
-                if len(parts) >= 4:
-                    version = parts[3]
-                    try:
-                        major, minor = map(int, version.split("."))
-                        count = int(count_str.replace(",", "").replace(" documents", ""))
-                        stable_candidates.append((major, minor, version, pattern, count))
-                    except (ValueError, IndexError):
-                        continue
+        for candidates in by_channel.values():
+            candidates.sort(reverse=True)  # highest generation first
 
-        if stable_candidates:
-            stable_candidates.sort(key=lambda x: (x[0], x[1], x[4]), reverse=True)
-            current_stable = stable_candidates[0]
-            resolved["stable"] = current_stable[3]
-            resolved[current_stable[2]] = current_stable[3]
+        resolved: dict[str, str] = {}
+        if "unstable" in by_channel:
+            resolved["unstable"] = by_channel["unstable"][0][1]
 
-            version_patterns: dict[str, tuple[str, int]] = {}
-            for _major, _minor, version, pattern, count in stable_candidates:
-                if version not in version_patterns or count > version_patterns[version][1]:
-                    version_patterns[version] = (pattern, count)
-            for version, (pattern, _count) in version_patterns.items():
-                resolved[version] = pattern
+        release_versions = sorted(
+            (v for v in by_channel if v != "unstable"),
+            key=lambda v: tuple(int(p) for p in v.split(".")),
+            reverse=True,
+        )
 
-        if "stable" in resolved:
+        for version in release_versions:
+            resolved[version] = by_channel[version][0][1]
+
+        if release_versions:
+            resolved["stable"] = resolved[release_versions[0]]
             resolved["beta"] = resolved["stable"]
 
         if not resolved:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,16 +169,127 @@ class TestChannelCache:
         assert "unstable" in result
 
     @patch("mcp_nixos.sources.base.requests.post")
-    def test_discover_channels(self, mock_post):
-        mock_resp = Mock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"count": 100000}
-        mock_post.return_value = mock_resp
+    @patch("mcp_nixos.sources.base.requests.get")
+    def test_discover_channels(self, mock_get, mock_post):
+        # _cat/aliases returns the list of `latest-*-nixos-*` aliases live on
+        # the backend; each one then gets a per-alias _count probe.
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"},
+            {"alias": "latest-46-nixos-25.11", "index": "nixos-46-25.11-cafebabe"},
+            {"alias": ".kibana", "index": ".kibana_1"},  # noise the discovery must skip
+        ]
+        mock_get.return_value = aliases_resp
+
+        count_resp = Mock()
+        count_resp.status_code = 200
+        count_resp.json.return_value = {"count": 100000}
+        mock_post.return_value = count_resp
 
         cache = ChannelCache()
         cache.available_channels = None
         result = cache.get_available()
-        assert isinstance(result, dict)
+        assert set(result) == {"latest-48-nixos-unstable", "latest-46-nixos-25.11"}
+
+    @patch("mcp_nixos.sources.base.requests.post")
+    @patch("mcp_nixos.sources.base.requests.get")
+    def test_discover_skips_zero_count_aliases(self, mock_get, mock_post):
+        """An alias that responds with count=0 must not appear in available."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"},
+            {"alias": "latest-99-nixos-99.99", "index": "nixos-99-99.99-empty"},
+        ]
+        mock_get.return_value = aliases_resp
+
+        responses = {
+            "latest-48-nixos-unstable": (200, {"count": 100000}),
+            "latest-99-nixos-99.99": (200, {"count": 0}),
+        }
+
+        def fake_post(url, **_kwargs):
+            for alias, (status, body) in responses.items():
+                if alias in url:
+                    resp = Mock()
+                    resp.status_code = status
+                    resp.json.return_value = body
+                    return resp
+            raise AssertionError(f"unexpected POST: {url}")
+
+        mock_post.side_effect = fake_post
+
+        cache = ChannelCache()
+        cache.available_channels = None
+        assert cache.get_available() == {"latest-48-nixos-unstable": "100,000 documents"}
+
+    @patch("mcp_nixos.sources.base.requests.get")
+    def test_discover_returns_empty_on_api_error(self, mock_get):
+        """Non-200 from _cat/aliases must short-circuit to {} so the caller
+        falls back to FALLBACK_CHANNELS instead of crashing."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 503
+        mock_get.return_value = aliases_resp
+
+        cache = ChannelCache()
+        cache.available_channels = None
+        assert cache.get_available() == {}
+
+    def test_resolve_picks_highest_generation_for_unstable(self):
+        """Regression: previously `_resolve_channels` picked the first unstable
+        match in dict-insertion order, which yielded the lowest generation. The
+        freshest data lives on the highest generation, so the resolver must
+        prefer that even when older generations are still live."""
+        cache = ChannelCache()
+        cache.available_channels = {
+            "latest-45-nixos-unstable": "400,000 documents",
+            "latest-46-nixos-unstable": "410,000 documents",
+            "latest-48-nixos-unstable": "450,000 documents",
+            "latest-47-nixos-unstable": "440,000 documents",
+        }
+        resolved = cache.get_resolved()
+        assert resolved["unstable"] == "latest-48-nixos-unstable"
+
+    def test_resolve_picks_highest_generation_per_release(self):
+        """Same logic for release channels: when multiple generations of the
+        same release version are live during a rollover window, pick the max."""
+        cache = ChannelCache()
+        cache.available_channels = {
+            "latest-46-nixos-25.11": "400,000 documents",
+            "latest-48-nixos-25.11": "414,000 documents",
+            "latest-47-nixos-25.11": "414,000 documents",
+        }
+        resolved = cache.get_resolved()
+        assert resolved["25.11"] == "latest-48-nixos-25.11"
+        assert resolved["stable"] == "latest-48-nixos-25.11"
+        assert resolved["beta"] == "latest-48-nixos-25.11"
+
+    def test_resolve_picks_highest_release_version_for_stable(self):
+        """`stable` aliases to the newest release version (not the newest
+        generation across versions)."""
+        cache = ChannelCache()
+        cache.available_channels = {
+            "latest-48-nixos-25.05": "350,000 documents",
+            "latest-48-nixos-25.11": "410,000 documents",
+            "latest-48-nixos-26.05": "420,000 documents",
+        }
+        resolved = cache.get_resolved()
+        assert resolved["stable"] == "latest-48-nixos-26.05"
+        assert resolved["beta"] == "latest-48-nixos-26.05"
+        assert resolved["25.05"] == "latest-48-nixos-25.05"
+        assert resolved["25.11"] == "latest-48-nixos-25.11"
+        assert resolved["26.05"] == "latest-48-nixos-26.05"
+
+    def test_resolve_unstable_without_stable_releases(self):
+        """Only unstable is live — resolver must still produce a usable map
+        and must not synthesize a fake `stable` / `beta` entry."""
+        cache = ChannelCache()
+        cache.available_channels = {
+            "latest-48-nixos-unstable": "450,000 documents",
+        }
+        resolved = cache.get_resolved()
+        assert resolved == {"unstable": "latest-48-nixos-unstable"}
 
 
 @pytest.mark.unit

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,8 +168,8 @@ class TestChannelCache:
         assert cache.using_fallback is True
         assert "unstable" in result
 
-    @patch("mcp_nixos.sources.base.requests.post")
-    @patch("mcp_nixos.sources.base.requests.get")
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
     def test_discover_channels(self, mock_get, mock_post):
         # _cat/aliases returns the list of `latest-*-nixos-*` aliases live on
         # the backend; each one then gets a per-alias _count probe.
@@ -192,8 +192,8 @@ class TestChannelCache:
         result = cache.get_available()
         assert set(result) == {"latest-48-nixos-unstable", "latest-46-nixos-25.11"}
 
-    @patch("mcp_nixos.sources.base.requests.post")
-    @patch("mcp_nixos.sources.base.requests.get")
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
     def test_discover_skips_zero_count_aliases(self, mock_get, mock_post):
         """An alias that responds with count=0 must not appear in available."""
         aliases_resp = Mock()
@@ -224,7 +224,7 @@ class TestChannelCache:
         cache.available_channels = None
         assert cache.get_available() == {"latest-48-nixos-unstable": "100,000 documents"}
 
-    @patch("mcp_nixos.sources.base.requests.get")
+    @patch("mcp_nixos.caches.requests.get")
     def test_discover_returns_empty_on_api_error(self, mock_get):
         """Non-200 from _cat/aliases must short-circuit to {} so the caller
         falls back to FALLBACK_CHANNELS instead of crashing."""


### PR DESCRIPTION
## AI Usage Disclosure
*AI-assisted: investigated, written, and tested with Claude Code.*

## Summary

`ChannelCache._discover_available_channels` currently probes a hardcoded `generations = [43, 44, 45, 46]` × `versions = [...]` cartesian product against the Elasticsearch backend. This produces two related failure modes:

1. **Bit-rot.** Once Hydra publishes `latest-47-nixos-*` or higher, the probe loop never sees the newer indices. They stay invisible until someone bumps the list and cuts a release. As of filing, `nixos-unstable` is live at gens 45, 46, **47, and 48** — gens 47 and 48 are entirely invisible to `mcp-nixos`.

2. **"First wins" picks the wrong generation.** `_resolve_channels` iterates `available` and breaks on the first `"unstable"` match. Because `available` is populated in *ascending* generation order, `unstable` resolves to the **lowest** live generation. With gens 45 and 46 both live, the resolver picks gen 45 — two channel rolls behind what the search.nixos.org web UI returns for the same channel. (The release-channel path was less affected because it already sorted by version, but still capped by the hardcoded generation ceiling.)

**User-visible symptom that surfaced this:** `nix({"action":"info","query":"python313Packages.aiohttp","channel":"unstable"})` returns `Version: 3.13.3` (from gen 45), while the web UI for `nixos-unstable` shows `3.13.5` (from gen 48). Same channel, same backend, different indexed generation.

## What changed

- **`mcp_nixos/caches.py`**:
  - `_discover_available_channels` now makes a single `GET /_cat/aliases?format=json` call, filters with a regex on `latest-<gen>-nixos-<channel>` (so noise like `.kibana`, `latest-48-group-manual`, etc. is skipped), and keeps the existing per-alias `_count` probe so empty indices are still excluded.
  - `_resolve_channels` buckets candidates per channel and picks the **maximum generation** for every channel — making the unstable and release paths symmetric. `stable` and `beta` still alias to the highest live release version.
- **`.github/copilot-instructions.md`**: updated the "Channel Resolution System" description to match the new mechanism.
- **`tests/test_server.py`**: updated `test_discover_channels` to mock the new `_cat/aliases` + `_count` call sequence, and added tests for:
  - skipping aliases with `count == 0`
  - returning `{}` on a non-200 from `_cat/aliases` (so callers fall back to `FALLBACK_CHANNELS`)
  - max-generation selection for `unstable`
  - max-generation selection per release version
  - `stable`/`beta` aliasing the highest release version
  - resolving when only `unstable` is live (no release channels)

## Smoke test against the live backend

```text
Before:  unstable -> latest-45-nixos-unstable   # gen 45, aiohttp 3.13.3
After:   unstable -> latest-48-nixos-unstable   # gen 48, aiohttp 3.13.5
```

## Test plan

- [x] `pytest -m "not integration"` — 288 passed, 2 skipped, 64 deselected
- [x] `ruff check mcp_nixos/ tests/` — clean
- [x] `ruff format --check mcp_nixos/ tests/` — clean
- [x] `mypy mcp_nixos/` — no issues
- [x] Live smoke test: instantiate `ChannelCache`, call `get_resolved()` against the real `search.nixos.org/backend` — confirms `unstable` now resolves to the highest live generation

## Notes

- This PR is scoped narrowly to the discovery + resolution bug. A follow-up could opportunistically use the alias-target index name (e.g. `nixos-48-unstable-<sha>` returned by `_cat/aliases`) to short-circuit the GitHub-API round-trip in `_channel_revision`, since the SHA suffix is the exact nixpkgs commit Hydra built the index from. Happy to follow up if useful.
- `FALLBACK_CHANNELS` in `config.py` is unchanged in this PR; it only kicks in when API discovery itself fails, which is now a stricter (and therefore less frequently triggered) condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated channel resolution docs with current examples and clarified how channels are discovered and chosen (including the new stable example).

* **Refactor**
  * Switched to dynamic channel discovery and selection to automatically pick the latest generation per channel and improve reliability while keeping existing fallback behavior.

* **Tests**
  * Expanded coverage for discovery, selection, edge cases, and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utensils/mcp-nixos/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->