### PR TITLE
fix(nixvim): read options from NuschtOS data/options/chunks/N.json

### DIFF
--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -158,56 +159,68 @@ class NixvimCache:
 
     This loader walks chunks sequentially until it sees a 404, flattens them
     into a single in-memory list, and serves subsequent calls from cache. The
-    full set is small enough (a few MB) to hold in memory and re-scan for
-    keyword matching, avoiding the WASM dependency entirely.
+    full set currently runs to ~60 chunks / ~17k options / a few MB and fits
+    comfortably in memory; we re-scan in Python for keyword matching, avoiding
+    the WASM dependency entirely.
     """
 
     def __init__(self) -> None:
         self.options: list[dict[str, Any]] | None = None
+        self._init_lock = threading.Lock()
 
     def get_options(self) -> list[dict[str, Any]]:
         """Fetch and cache all Nixvim options from NuschtOS chunk JSON."""
         if self.options is not None:
             return self.options
 
-        all_options: list[dict[str, Any]] = []
-        chunk_id = 0
-        try:
-            while True:
-                url = f"{NIXVIM_OPTIONS_CHUNKS_BASE}/{chunk_id}.json"
-                resp = requests.get(url, timeout=30)
+        with self._init_lock:
+            if self.options is not None:
+                return self.options
 
-                if resp.status_code == 404:
-                    # Treat as end-of-pagination — but a 404 on the *first*
-                    # chunk almost always means a config error (wrong base URL
-                    # or layout change), so surface that distinctly.
-                    if chunk_id == 0:
+            all_options: list[dict[str, Any]] = []
+            chunk_id = 0
+            try:
+                while True:
+                    url = f"{NIXVIM_OPTIONS_CHUNKS_BASE}/{chunk_id}.json"
+                    resp = requests.get(url, timeout=30)
+
+                    if resp.status_code == 404:
+                        # Treat as end-of-pagination — but a 404 on the *first*
+                        # chunk almost always means a config error (wrong base URL
+                        # or layout change), so surface that distinctly.
+                        if chunk_id == 0:
+                            raise APIError(
+                                f"First Nixvim options chunk returned 404 at {url}; "
+                                "the NuschtOS data layout may have changed again."
+                            )
+                        break
+
+                    resp.raise_for_status()
+                    chunk_data = resp.json()
+
+                    if isinstance(chunk_data, list):
+                        all_options.extend(chunk_data)
+                    else:
+                        # Unexpected payload: a layout/format change in the
+                        # middle of the chunk sequence. Fail loud so we don't
+                        # silently cache a partial option set.
                         raise APIError(
-                            f"First Nixvim options chunk returned 404 at {url}; "
-                            "the NuschtOS data layout may have changed again."
+                            f"Unexpected Nixvim options payload at {url}: "
+                            f"expected JSON list, got {type(chunk_data).__name__}."
                         )
-                    break
 
-                resp.raise_for_status()
-                chunk_data = resp.json()
+                    chunk_id += 1
 
-                if isinstance(chunk_data, list):
-                    all_options.extend(chunk_data)
-                else:
-                    break  # Unexpected format; stop rather than loop forever
-
-                chunk_id += 1
-
-            self.options = all_options
-            return self.options
-        except requests.Timeout as exc:
-            raise APIError("Timeout fetching Nixvim options") from exc
-        except requests.RequestException as exc:
-            raise APIError(f"Failed to fetch Nixvim options: {exc}") from exc
-        except APIError:
-            raise
-        except Exception as exc:
-            raise APIError(f"Failed to parse Nixvim options: {exc}") from exc
+                self.options = all_options
+                return self.options
+            except requests.Timeout as exc:
+                raise APIError("Timeout fetching Nixvim options") from exc
+            except requests.RequestException as exc:
+                raise APIError(f"Failed to fetch Nixvim options: {exc}") from exc
+            except APIError:
+                raise
+            except Exception as exc:
+                raise APIError(f"Failed to parse Nixvim options: {exc}") from exc
 
 
 nixvim_cache = NixvimCache()

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -18,7 +18,7 @@ from .config import (
     NIXDEV_SEARCH_INDEX,
     NIXOS_API,
     NIXOS_AUTH,
-    NIXVIM_META_BASE,
+    NIXVIM_OPTIONS_CHUNKS_BASE,
     NOOGLE_API,
     NVF_OPTIONS_URL,
     APIError,
@@ -149,26 +149,44 @@ channel_cache = ChannelCache()
 
 
 class NixvimCache:
-    """Cache for Nixvim options fetched from NuschtOS meta JSON (paginated)."""
+    """Cache for Nixvim options fetched from NuschtOS chunked JSON.
+
+    As of mid-2026 the NuschtOS search frontend for nix-community/nixvim was
+    reorganized: the old `…/search/meta/N.json` layout was removed and replaced
+    with a WASM-backed frontend at `…/search/data/options/`. The options data
+    itself is exposed as `chunks/N.json` (≈300 options per chunk, JSON array).
+
+    This loader walks chunks sequentially until it sees a 404, flattens them
+    into a single in-memory list, and serves subsequent calls from cache. The
+    full set is small enough (a few MB) to hold in memory and re-scan for
+    keyword matching, avoiding the WASM dependency entirely.
+    """
 
     def __init__(self) -> None:
         self.options: list[dict[str, Any]] | None = None
 
     def get_options(self) -> list[dict[str, Any]]:
-        """Fetch and cache all Nixvim options from NuschtOS meta JSON chunks."""
+        """Fetch and cache all Nixvim options from NuschtOS chunk JSON."""
         if self.options is not None:
             return self.options
 
+        all_options: list[dict[str, Any]] = []
+        chunk_id = 0
         try:
-            all_options: list[dict[str, Any]] = []
-            chunk_id = 0
-
             while True:
-                url = f"{NIXVIM_META_BASE}/{chunk_id}.json"
+                url = f"{NIXVIM_OPTIONS_CHUNKS_BASE}/{chunk_id}.json"
                 resp = requests.get(url, timeout=30)
 
                 if resp.status_code == 404:
-                    break  # No more chunks
+                    # Treat as end-of-pagination — but a 404 on the *first*
+                    # chunk almost always means a config error (wrong base URL
+                    # or layout change), so surface that distinctly.
+                    if chunk_id == 0:
+                        raise APIError(
+                            f"First Nixvim options chunk returned 404 at {url}; "
+                            "the NuschtOS data layout may have changed again."
+                        )
+                    break
 
                 resp.raise_for_status()
                 chunk_data = resp.json()
@@ -176,7 +194,7 @@ class NixvimCache:
                 if isinstance(chunk_data, list):
                     all_options.extend(chunk_data)
                 else:
-                    break  # Unexpected format
+                    break  # Unexpected format; stop rather than loop forever
 
                 chunk_id += 1
 
@@ -186,6 +204,8 @@ class NixvimCache:
             raise APIError("Timeout fetching Nixvim options") from exc
         except requests.RequestException as exc:
             raise APIError(f"Failed to fetch Nixvim options: {exc}") from exc
+        except APIError:
+            raise
         except Exception as exc:
             raise APIError(f"Failed to parse Nixvim options: {exc}") from exc
 

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -41,9 +41,17 @@ FLAKE_INDEX = "latest-44-group-manual"
 FLAKEHUB_API = "https://api.flakehub.com"
 FLAKEHUB_USER_AGENT = f"mcp-nixos/{__version__}"
 
-# Nixvim options via NuschtOS search infrastructure (paginated, ~300 options per chunk)
+# Nixvim options via NuschtOS search infrastructure.
+# Layout (reorganized mid-2026; old `…/search/meta/N.json` path was removed):
+#   data/options/chunks/N.json  →  ~300 options per chunk, JSON array of Option objects
+#   data/options/meta.json      →  scope metadata (licenses/maintainers/teams)
+#   data/options/index.ixx      →  binary search index (WASM-backed; not used here)
+# We walk chunks until 404 and search in Python. The full set fits in memory
+# (~20 chunks × 300 options × small payload ≈ a few MB).
 # Credit: https://github.com/NuschtOS/search - Simple and fast static-page NixOS option search
-NIXVIM_META_BASE = "https://nix-community.github.io/nixvim/search/meta"
+NIXVIM_OPTIONS_CHUNKS_BASE = "https://nix-community.github.io/nixvim/search/data/options/chunks"
+# Kept for backward compatibility / potential scope lookups; not used by the chunked loader.
+NIXVIM_META_BASE = "https://nix-community.github.io/nixvim/search/data"
 
 # NVF options from the latest published (unstable) documentation.
 NVF_OPTIONS_URL = "https://nvf.notashelf.dev/options.html"

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -46,8 +46,8 @@ FLAKEHUB_USER_AGENT = f"mcp-nixos/{__version__}"
 #   data/options/chunks/N.json  →  ~300 options per chunk, JSON array of Option objects
 #   data/options/meta.json      →  scope metadata (licenses/maintainers/teams)
 #   data/options/index.ixx      →  binary search index (WASM-backed; not used here)
-# We walk chunks until 404 and search in Python. The full set fits in memory
-# (~20 chunks × 300 options × small payload ≈ a few MB).
+# We walk chunks until 404 and search in Python. The current catalogue is
+# approximately 60 chunks / 17,000 options and fits comfortably in memory.
 # Credit: https://github.com/NuschtOS/search - Simple and fast static-page NixOS option search
 NIXVIM_OPTIONS_CHUNKS_BASE = "https://nix-community.github.io/nixvim/search/data/options/chunks"
 # Kept for backward compatibility / potential scope lookups; not used by the chunked loader.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -667,6 +667,133 @@ class TestNixDevFunctions:
 
 
 @pytest.mark.unit
+class TestNixvimCache:
+    """Test NixvimCache chunked loader (issue #167)."""
+
+    def _fresh_cache(self):
+        """Reset the module-level nixvim_cache singleton so each test gets a clean slate."""
+        from mcp_nixos import caches
+
+        caches.nixvim_cache = caches.NixvimCache()
+        return caches.nixvim_cache
+
+    def _chunk_resp(self, chunk):
+        """Build a Mock response that returns `chunk` from .json() once."""
+        resp = Mock(status_code=200, raise_for_status=Mock())
+
+        def _json():
+            return chunk
+
+        resp.json = _json
+        return resp
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_loads_chunks_until_404(self, mock_get):
+        """Walks chunks 0,1,2 and stops at the first 404."""
+        chunk0 = [{"name": "opt0", "type": "boolean", "description": ""}]
+        chunk1 = [{"name": "opt1", "type": "boolean", "description": ""}]
+        chunk2 = [{"name": "opt2", "type": "boolean", "description": ""}]
+
+        mock_get.side_effect = [
+            self._chunk_resp(chunk0),
+            self._chunk_resp(chunk1),
+            self._chunk_resp(chunk2),
+            Mock(status_code=404),
+        ]
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+
+        assert len(options) == 3
+        assert [o["name"] for o in options] == ["opt0", "opt1", "opt2"]
+        assert mock_get.call_count == 4  # 3 chunks + 1 probe that 404'd
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_empty_first_chunk_still_stops(self, mock_get):
+        """An empty first chunk is not an error — just means zero options."""
+        mock_get.side_effect = [
+            self._chunk_resp([]),
+            Mock(status_code=404),
+        ]
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+
+        assert options == []
+        assert mock_get.call_count == 2  # chunk 0 + 404 probe
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_404_on_first_chunk_raises(self, mock_get):
+        """A 404 on chunk 0 raises APIError so a wrong URL doesn't masquerade as 'no options'."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.return_value = Mock(status_code=404)
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "First Nixvim options chunk" in str(exc_info.value)
+        assert mock_get.call_count == 1
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_request_exception_raises(self, mock_get):
+        """A network error during fetch surfaces as APIError."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.side_effect = requests.RequestException("connection reset")
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "Failed to fetch" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_timeout_raises(self, mock_get):
+        """A timeout surfaces as APIError with a Timeout message."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.side_effect = requests.Timeout()
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "Timeout" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_cache_reused_on_subsequent_calls(self, mock_get):
+        """A second call returns the cached list without re-fetching."""
+        chunk = [{"name": "opt0", "type": "boolean", "description": ""}]
+        mock_get.side_effect = [
+            self._chunk_resp(chunk),
+            Mock(status_code=404),
+        ]
+
+        cache = self._fresh_cache()
+        first = cache.get_options()
+        second = cache.get_options()
+
+        assert first is second
+        # 1 chunk + 1 404 probe on the first call; zero network calls on the second.
+        assert mock_get.call_count == 2
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_unexpected_payload_breaks_loop(self, mock_get):
+        """A non-list response stops the walk without raising."""
+
+        unexpected_resp = Mock(status_code=200, raise_for_status=Mock())
+        unexpected_resp.json = lambda: {"not": "a list"}
+
+        mock_get.side_effect = [
+            self._chunk_resp([{"name": "a"}]),
+            unexpected_resp,
+        ]
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+        assert len(options) == 1
+
+
+@pytest.mark.unit
 class TestPlainTextOutputDocs:
     """Verify wiki/nix-dev outputs are plain text."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -780,7 +780,7 @@ class TestNixvimCache:
     def test_unexpected_payload_raises(self, mock_get):
         """A non-list payload mid-walk raises APIError so a layout change
         doesn't silently cache a partial option set."""
-        from mcp_nixos.server import APIError
+        from mcp_nixos.caches import APIError
 
         unexpected_resp = Mock(status_code=200, raise_for_status=Mock())
         unexpected_resp.json = lambda: {"not": "a list"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -777,8 +777,10 @@ class TestNixvimCache:
         assert mock_get.call_count == 2
 
     @patch("mcp_nixos.caches.requests.get")
-    def test_unexpected_payload_breaks_loop(self, mock_get):
-        """A non-list response stops the walk without raising."""
+    def test_unexpected_payload_raises(self, mock_get):
+        """A non-list payload mid-walk raises APIError so a layout change
+        doesn't silently cache a partial option set."""
+        from mcp_nixos.server import APIError
 
         unexpected_resp = Mock(status_code=200, raise_for_status=Mock())
         unexpected_resp.json = lambda: {"not": "a list"}
@@ -789,8 +791,30 @@ class TestNixvimCache:
         ]
 
         cache = self._fresh_cache()
-        options = cache.get_options()
-        assert len(options) == 1
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "Unexpected Nixvim options payload" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_concurrent_first_call_only_fetches_once(self, mock_get):
+        """Double-checked locking: N concurrent first calls perform the
+        walk exactly once, not N times."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        # 1 listing-style "first chunk" + 1 trailing 404 = 2 calls per walk.
+        # The lock must collapse N concurrent callers into a single walk.
+        chunk = [{"name": "a"}]
+        mock_get.side_effect = [
+            self._chunk_resp(chunk),
+            Mock(status_code=404),
+        ] * 50  # plenty of responses for any number of concurrent walks
+
+        cache = self._fresh_cache()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: cache.get_options(), range(20)))
+
+        # Exactly one walk happened, so exactly 2 network calls.
+        assert mock_get.call_count == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #167.

## What broke

The \`nixvim\` source was returning 0 options for every query because
\`NIXVIM_META_BASE\` pointed at the old NuschtOS \`…/search/meta/N.json\`
layout, which was removed in mid-2026. The reorganised frontend now
exposes options as \`…/search/data/options/chunks/N.json\` (≈300 options
per chunk, JSON array of \`Option\` objects).

A 404 on chunk 0 was silently treated as "end of pagination", so the
cache reported "0 options" instead of failing loudly.

## What changed

- \`mcp_nixos/config.py\` — point at the new chunked base, keep the old
  \`NIXVIM_META_BASE\` constant for backward compatibility.
- \`mcp_nixos/caches.py\` — rewrite \`NixvimCache.get_options()\` to walk
  \`chunks/{0..N}.json\` until 404, flatten, and cache. A 404 on chunk 0
  now raises \`APIError\` with a clear "the NuschtOS data layout may have
  changed again" message.
- \`tests/test_server.py\` — 7 new unit tests covering the chunk walk,
  the first-chunk 404 path, request/timeout errors, cache reuse, and
  the unexpected-payload break.

## Verified

- 235 unit tests pass (241 across all three branches; 235 on this one).
- \`ruff check\`, \`ruff format --check\`, and \`mypy\` are clean.
- Live smoke test: \`NixvimCache().get_options()\` returns 17,695 options,
  \`programs.git.enable\`-style searches return expected matches.

## Related

- #159 (ningw42) — broader channel-discovery rewrite; independent of this fix.
- The WASM-backed search index at \`data/options/index.ixx\` is intentionally
  not used here; the full set fits in memory (a few MB) and we search in
  Python to keep the dependency surface small.

Work created during Nix Taco Sprint: https://tacosprint.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nixvim option loading to use a chunked static index, aggregating options from sequential chunks.
  * Enhanced error handling: clearer failures when the chunk layout/base URL changes, and strict validation to reject unexpected payload shapes.
  * Improved reliability under concurrent access by ensuring only one initial load occurs.
* **Tests**
  * Added unit tests covering chunk pagination behavior (including 404/empty cases), caching reuse, error conversions/timeouts, payload-shape validation, and concurrent first-call collapsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->