### PR TITLE
fix(home-manager): migrate to mdBook-rendered options site

### DIFF
--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -264,37 +265,50 @@ class HomeManagerCache:
     def __init__(self) -> None:
         self.options: list[dict[str, Any]] | None = None
         self._by_name: dict[str, dict[str, Any]] | None = None
+        self._init_lock = threading.Lock()
 
     def get_options(self) -> list[dict[str, Any]]:
-        """Fetch and cache all Home Manager options."""
+        """Fetch and cache all Home Manager options.
+
+        Concurrency-safe via double-checked locking: N concurrent first
+        callers all see the cold cache, but only one performs the walk;
+        the rest wait and consume the cached list.
+        """
         if self.options is not None:
             return self.options
 
-        page_urls = self._discover_page_urls()
-        if not page_urls:
-            raise APIError("No Home Manager option pages discovered")
+        with self._init_lock:
+            if self.options is not None:
+                return self.options
 
-        all_options: list[dict[str, Any]] = []
-        try:
-            with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
-                futures = {pool.submit(self._fetch_page_options, url): url for url in page_urls}
-                for future in as_completed(futures):
-                    url = futures[future]
-                    try:
-                        page_options = future.result()
-                    except requests.RequestException as exc:
-                        raise APIError(f"Failed to fetch {url}: {exc}") from exc
-                    except Exception as exc:
-                        raise APIError(f"Failed to parse {url}: {exc}") from exc
-                    all_options.extend(page_options)
-        except requests.Timeout as exc:
-            raise APIError("Timeout fetching Home Manager options") from exc
-        except requests.RequestException as exc:
-            raise APIError(f"Failed to fetch Home Manager options: {exc}") from exc
+            page_urls = self._discover_page_urls()
+            if not page_urls:
+                raise APIError("No Home Manager option pages discovered")
 
-        self.options = all_options
-        self._by_name = {opt["name"]: opt for opt in all_options if opt.get("name")}
-        return self.options
+            all_options: list[dict[str, Any]] = []
+            try:
+                with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
+                    futures = {pool.submit(self._fetch_page_options, url): url for url in page_urls}
+                    for future in as_completed(futures):
+                        url = futures[future]
+                        try:
+                            page_options = future.result()
+                        except requests.RequestException as exc:
+                            raise APIError(f"Failed to fetch {url}: {exc}") from exc
+                        except Exception as exc:
+                            raise APIError(f"Failed to parse {url}: {exc}") from exc
+                        all_options.extend(page_options)
+            except requests.Timeout as exc:
+                raise APIError("Timeout fetching Home Manager options") from exc
+            except requests.RequestException as exc:
+                raise APIError(f"Failed to fetch Home Manager options: {exc}") from exc
+
+            # Sort by name for deterministic downstream output (search, info,
+            # browse) — `as_completed()` yields in completion order.
+            all_options.sort(key=lambda opt: opt.get("name", ""))
+            self.options = all_options
+            self._by_name = {opt["name"]: opt for opt in all_options if opt.get("name")}
+            return self.options
 
     def get_by_name(self, name: str) -> dict[str, Any] | None:
         """Look up a single option by its exact name. Lazy-loads the cache."""
@@ -305,35 +319,57 @@ class HomeManagerCache:
     def _discover_page_urls(self) -> list[str]:
         """Enumerate option-page URLs by reading three directory listings.
 
-        Falls back to an empty list on any failure; the caller raises APIError
-        so the user sees a clear error rather than a silent 0-options result.
+        Returns unique URLs in the order the listings declared them. If any
+        individual listing fetch fails (network error or non-2xx), the
+        failure is collected and raised as a single `APIError` so a partial
+        index isn't silently cached — a missing listings means the user is
+        about to see "0 options" for whatever section didn't load.
         """
+        from urllib.parse import urljoin, urlparse
+
+        allowed = urlparse(HOME_MANAGER_OPTIONS_DIR)
         urls: list[str] = []
+        failed: list[str] = []
         for sub in self._PAGE_LISTINGS:
             listing_url = f"{HOME_MANAGER_OPTIONS_DIR}/{sub}" if sub else f"{HOME_MANAGER_OPTIONS_DIR}/"
             try:
                 resp = requests.get(listing_url, timeout=15)
                 if resp.status_code != 200:
+                    failed.append(f"{listing_url} (HTTP {resp.status_code})")
                     continue
-                soup = BeautifulSoup(resp.content, "html.parser")
-                for link in soup.find_all("a", href=True):
-                    href = link["href"]
-                    # Skip the print.html / parent-directory links emitted by
-                    # GitHub Pages' directory listing.
-                    if not href.endswith(".html") or href.startswith("..") or href.startswith("?"):
-                        continue
-                    if sub == "":
-                        # Top-level: only accept "<name>.html" with no slashes
-                        # (e.g. "accounts.html", "fonts.html"). Subdirectory
-                        # entries ("programs/", "services/") and any nested
-                        # links are ignored.
-                        if "/" in href:
-                            continue
-                    # Subdir hrefs are bare filenames like "abaddon.html" —
-                    # the listing URL already provides the "programs/" prefix.
-                    urls.append(f"{listing_url}{href}")
-            except requests.RequestException:
+            except requests.RequestException as exc:
+                failed.append(f"{listing_url} ({exc})")
                 continue
+
+            soup = BeautifulSoup(resp.content, "html.parser")
+            for link in soup.find_all("a", href=True):
+                href = link["href"]
+                # Skip the print.html / parent-directory links emitted by
+                # GitHub Pages' directory listing.
+                if not href.endswith(".html") or href.startswith("..") or href.startswith("?"):
+                    continue
+                if sub == "":
+                    # Top-level: only accept "<name>.html" with no slashes
+                    # (e.g. "accounts.html", "fonts.html"). Subdirectory
+                    # entries ("programs/", "services/") and any nested
+                    # links are ignored.
+                    if "/" in href:
+                        continue
+                # SSRF guard: only follow links that resolve to the same
+                # scheme+host+path-prefix as HOME_MANAGER_OPTIONS_DIR. A
+                # compromised listing page can't pivot us into fetching
+                # arbitrary hosts.
+                candidate = urljoin(listing_url, href)
+                parsed = urlparse(candidate)
+                if parsed.scheme != "https" or parsed.netloc != allowed.netloc:
+                    continue
+                if not parsed.path.startswith(allowed.path):
+                    continue
+                urls.append(candidate)
+
+        if failed:
+            raise APIError("Failed to fetch Home Manager option listings: " + "; ".join(failed))
+
         # De-dup while preserving order.
         seen: set[str] = set()
         unique: list[str] = []
@@ -405,8 +441,18 @@ class HomeManagerCache:
                 if label in ("type", "default", "example"):
                     last_label = label
                     if label == "type":
-                        # The full <p> text is "Type: value" — strip the label.
-                        option["type"] = sibling.get_text(" ", strip=True)[len("Type:") :].strip()
+                        # The full <p> text is "Type: value" (or "Type
+                        # value" if the site drops the colon). Strip the label
+                        # text from the start and any leading colon so both
+                        # renderings produce the same value.
+                        em_text = em.get_text(strip=True)  # original case
+                        full = sibling.get_text(" ", strip=True)
+                        after = full
+                        for prefix in (f"{em_text}:", em_text, f"{em_text}:"):
+                            if after.startswith(prefix):
+                                after = after[len(prefix) :]
+                                break
+                        option["type"] = after.strip()
                     # default / example values are emitted in a *following*
                     # <pre><code>, so we don't set them here; we set them
                     # in the loop below when we see a <pre> right after a

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -2,12 +2,15 @@
 
 import json
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import requests
+from bs4 import BeautifulSoup
 
 from .config import (
     FALLBACK_CHANNELS,
+    HOME_MANAGER_OPTIONS_DIR,
     NIXDEV_SEARCH_INDEX,
     NIXOS_API,
     NIXOS_AUTH,
@@ -229,3 +232,215 @@ class NoogleCache:
 
 
 noogle_cache = NoogleCache()
+
+
+class HomeManagerCache:
+    """Cache for Home Manager options fetched from the mdBook-rendered site.
+
+    As of mid-2026 the home-manager docs are published as an mdBook site. The
+    legacy single-page `options.xhtml` is now a 1.4 KB JS redirect stub; the
+    real options live on ~600 per-page HTML files under `options/home-manager/`,
+    organised roughly as:
+
+      options/home-manager/                 →  ~30 top-level pages (accounts.html,
+                                               dconf.html, fonts.html, gtk.html, …)
+      options/home-manager/programs/         →  ~400 program pages (git.html,
+                                               helix.html, …)
+      options/home-manager/services/         →  ~170 service pages
+
+    Each page is a self-contained mdBook chapter that lists the options it
+    defines as `<h2 id="opt-...">` headers followed by `<p>` tags for the
+    description, type, default, and example. We discover page URLs from three
+    directory listings, then fetch each page in parallel (bounded thread pool)
+    and parse out the options into a single in-memory list.
+    """
+
+    # Subdirectories under HOME_MANAGER_OPTIONS_DIR that contain option pages.
+    _PAGE_LISTINGS = ("", "programs/", "services/")
+
+    # Cap concurrent fetches so we don't hammer GitHub Pages.
+    _MAX_WORKERS = 10
+
+    def __init__(self) -> None:
+        self.options: list[dict[str, Any]] | None = None
+        self._by_name: dict[str, dict[str, Any]] | None = None
+
+    def get_options(self) -> list[dict[str, Any]]:
+        """Fetch and cache all Home Manager options."""
+        if self.options is not None:
+            return self.options
+
+        page_urls = self._discover_page_urls()
+        if not page_urls:
+            raise APIError("No Home Manager option pages discovered")
+
+        all_options: list[dict[str, Any]] = []
+        try:
+            with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
+                futures = {pool.submit(self._fetch_page_options, url): url for url in page_urls}
+                for future in as_completed(futures):
+                    url = futures[future]
+                    try:
+                        page_options = future.result()
+                    except requests.RequestException as exc:
+                        raise APIError(f"Failed to fetch {url}: {exc}") from exc
+                    except Exception as exc:
+                        raise APIError(f"Failed to parse {url}: {exc}") from exc
+                    all_options.extend(page_options)
+        except requests.Timeout as exc:
+            raise APIError("Timeout fetching Home Manager options") from exc
+        except requests.RequestException as exc:
+            raise APIError(f"Failed to fetch Home Manager options: {exc}") from exc
+
+        self.options = all_options
+        self._by_name = {opt["name"]: opt for opt in all_options if opt.get("name")}
+        return self.options
+
+    def get_by_name(self, name: str) -> dict[str, Any] | None:
+        """Look up a single option by its exact name. Lazy-loads the cache."""
+        if self._by_name is None:
+            self.get_options()
+        return self._by_name.get(name) if self._by_name else None
+
+    def _discover_page_urls(self) -> list[str]:
+        """Enumerate option-page URLs by reading three directory listings.
+
+        Falls back to an empty list on any failure; the caller raises APIError
+        so the user sees a clear error rather than a silent 0-options result.
+        """
+        urls: list[str] = []
+        for sub in self._PAGE_LISTINGS:
+            listing_url = f"{HOME_MANAGER_OPTIONS_DIR}/{sub}" if sub else f"{HOME_MANAGER_OPTIONS_DIR}/"
+            try:
+                resp = requests.get(listing_url, timeout=15)
+                if resp.status_code != 200:
+                    continue
+                soup = BeautifulSoup(resp.content, "html.parser")
+                for link in soup.find_all("a", href=True):
+                    href = link["href"]
+                    # Skip the print.html / parent-directory links emitted by
+                    # GitHub Pages' directory listing.
+                    if not href.endswith(".html") or href.startswith("..") or href.startswith("?"):
+                        continue
+                    if sub == "":
+                        # Top-level: only accept "<name>.html" with no slashes
+                        # (e.g. "accounts.html", "fonts.html"). Subdirectory
+                        # entries ("programs/", "services/") and any nested
+                        # links are ignored.
+                        if "/" in href:
+                            continue
+                    # Subdir hrefs are bare filenames like "abaddon.html" —
+                    # the listing URL already provides the "programs/" prefix.
+                    urls.append(f"{listing_url}{href}")
+            except requests.RequestException:
+                continue
+        # De-dup while preserving order.
+        seen: set[str] = set()
+        unique: list[str] = []
+        for url in urls:
+            if url not in seen:
+                seen.add(url)
+                unique.append(url)
+        return unique
+
+    @staticmethod
+    def _fetch_page_options(url: str) -> list[dict[str, Any]]:
+        """Fetch a single page and extract the options declared on it.
+
+        Each option in the mdBook-rendered page looks like:
+
+            <h2 id="opt-NAME">NAME</h2>
+            <p>description (possibly multi-paragraph)</p>
+            <p><em>Type:</em> value</p>
+            <p><em>Default:</em></p>
+            <pre><code>value</code></pre>
+            <p><em>Example:</em></p>
+            <pre><code>value</code></pre>
+            <p><em>Declared by:</em></p>
+            <ul>…</ul>
+
+        We walk via `find_next_sibling()` so we only see the option's own
+        block elements (not nested `<em>`/`<a>`/`<code>` descendants).
+        """
+        resp = requests.get(url, timeout=20)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.content, "html.parser")
+
+        options: list[dict[str, Any]] = []
+        for h2 in soup.find_all("h2", id=True):
+            anchor_id = h2.get("id", "")
+            if not anchor_id.startswith("opt-"):
+                continue
+            name = anchor_id[4:]  # strip "opt-" prefix
+            if not name or "." not in name:
+                continue
+
+            option: dict[str, Any] = {
+                "name": name,
+                "type": "",
+                "description": "",
+                "default": "",
+                "example": "",
+            }
+
+            # Walk the siblings of the <h2> until the next <h2> (next option)
+            # or the end of the document. Sibling traversal keeps us at the
+            # block-element level; nested <em>/<a>/<code>/<pre> are handled
+            # by `get_text()`.
+            last_label: str | None = None
+            description_paragraphs: list[str] = []
+            for sibling in h2.find_next_siblings():
+                if sibling.name == "h2":
+                    break
+                if not hasattr(sibling, "name") or sibling.name is None:
+                    continue  # text node
+
+                # Extract the leading label from the first <em> child if any.
+                em = sibling.find("em")
+                if em is not None:
+                    label = em.get_text(strip=True).rstrip(":").lower()
+                else:
+                    label = None
+
+                if label in ("type", "default", "example"):
+                    last_label = label
+                    if label == "type":
+                        # The full <p> text is "Type: value" — strip the label.
+                        option["type"] = sibling.get_text(" ", strip=True)[len("Type:") :].strip()
+                    # default / example values are emitted in a *following*
+                    # <pre><code>, so we don't set them here; we set them
+                    # in the loop below when we see a <pre> right after a
+                    # "Default:" or "Example:" label.
+                elif sibling.name == "pre" and last_label in ("default", "example"):
+                    value = sibling.get_text(" ", strip=True)
+                    if last_label == "default":
+                        option["default"] = value
+                    else:
+                        option["example"] = value
+                    last_label = None  # consumed
+                elif sibling.name == "p":
+                    # Could be a continuation of the description, a "Declared
+                    # by:" block, or one of the multi-paragraph descriptions.
+                    text = sibling.get_text(" ", strip=True)
+                    if not text:
+                        continue
+                    lower = text.lower()
+                    if lower.startswith("declared by"):
+                        last_label = None
+                        continue
+                    if lower.startswith(("type:", "default:", "example:")):
+                        # Shouldn't reach here in well-formed pages but be
+                        # defensive.
+                        last_label = None
+                        continue
+                    if not option["description"]:
+                        description_paragraphs.append(text)
+                    else:
+                        description_paragraphs.append(text)
+
+            option["description"] = " ".join(description_paragraphs)
+            options.append(option)
+        return options
+
+
+home_manager_cache = HomeManagerCache()

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -31,7 +31,16 @@ FALLBACK_CHANNELS = {
     "beta": "latest-44-nixos-25.11",
 }
 
-HOME_MANAGER_URL = "https://nix-community.github.io/home-manager/options.xhtml"
+# Home Manager options are published as mdBook-rendered HTML split across
+# ~600 per-page files. The legacy single-page `options.xhtml` is now just a
+# 1.4 KB redirect stub. We discover pages from three directory listings
+# (top-level + programs/ + services/) and then fetch each page on demand to
+# extract its options. See HomeManagerCache for the full load strategy.
+HOME_MANAGER_BASE_URL = "https://nix-community.github.io/home-manager"
+HOME_MANAGER_OPTIONS_DIR = f"{HOME_MANAGER_BASE_URL}/options/home-manager"
+# Kept for backward compatibility — points at the new top-level options page
+# (which is itself a redirect, but tests + old imports may still reference it).
+HOME_MANAGER_URL = f"{HOME_MANAGER_OPTIONS_DIR}/index.html"
 DARWIN_URL = "https://nix-darwin.github.io/nix-darwin/manual/index.html"
 FLAKE_INDEX = "latest-44-group-manual"
 

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -23,10 +23,12 @@ from . import __version__
 # Import from our modules
 from .caches import (
     ChannelCache,
+    HomeManagerCache,
     NixDevCache,
     NixvimCache,
     NoogleCache,
     channel_cache,
+    home_manager_cache,
     nixdev_cache,
     nixvim_cache,
     noogle_cache,
@@ -653,10 +655,12 @@ __all__ = [
     "NixvimCache",
     "NixDevCache",
     "NoogleCache",
+    "HomeManagerCache",
     "channel_cache",
     "nixvim_cache",
     "nixdev_cache",
     "noogle_cache",
+    "home_manager_cache",
     # Utility functions
     "strip_html",
     "error",

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -10,7 +10,6 @@ from .. import __version__
 from ..caches import channel_cache, home_manager_cache
 from ..config import (
     DARWIN_URL,
-    HOME_MANAGER_URL,
     NIXOS_API,
     NIXOS_AUTH,
     APIError,
@@ -229,8 +228,10 @@ def _browse_options(source: str, prefix: str) -> str:
                 {"name": o["name"], "description": o.get("description", "")} for o in options_raw if o.get("name")
             ]
         else:
-            url = HOME_MANAGER_URL if source == "home-manager" else DARWIN_URL
-            options = parse_html_options(url, limit=5000)
+            # source is "darwin" (the only other value permitted by the
+            # server's action=browse allow-list). The dead `if source == ...`
+            # is gone — the URL is unambiguously DARWIN_URL.
+            options = parse_html_options(DARWIN_URL, limit=5000)
             options = [{"name": o["name"], "description": o.get("description", "")} for o in options if o.get("name")]
 
         if prefix:

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -7,7 +7,7 @@ from typing import Any
 import requests
 
 from .. import __version__
-from ..caches import channel_cache
+from ..caches import channel_cache, home_manager_cache
 from ..config import (
     DARWIN_URL,
     HOME_MANAGER_URL,
@@ -215,23 +215,38 @@ def _list_channels() -> str:
 
 def _browse_options(source: str, prefix: str) -> str:
     """Browse Home Manager or nix-darwin options by prefix, or list categories."""
-    url = HOME_MANAGER_URL if source == "home-manager" else DARWIN_URL
     source_name = "Home Manager" if source == "home-manager" else "nix-darwin"
 
     try:
+        if source == "home-manager":
+            # Home Manager uses a multi-page mdBook site; read from the cache
+            # populated by HomeManagerCache instead of a single HTML page.
+            try:
+                options_raw = home_manager_cache.get_options()
+            except APIError:
+                raise
+            options = [
+                {"name": o["name"], "description": o.get("description", "")} for o in options_raw if o.get("name")
+            ]
+        else:
+            url = HOME_MANAGER_URL if source == "home-manager" else DARWIN_URL
+            options = parse_html_options(url, limit=5000)
+            options = [{"name": o["name"], "description": o.get("description", "")} for o in options if o.get("name")]
+
         if prefix:
-            options = parse_html_options(url, "", prefix)
-            if not options:
+            matches = [o for o in options if o["name"].startswith(prefix + ".") or o["name"] == prefix]
+            if not matches:
                 return f"No {source_name} options found with prefix '{prefix}'"
-            results = [f"{source_name} options with prefix '{prefix}' ({len(options)} found):\n"]
-            for opt in sorted(options, key=lambda x: x["name"]):
+            results = [f"{source_name} options with prefix '{prefix}' ({len(matches)} found):\n"]
+            for opt in sorted(matches, key=lambda x: x["name"])[:100]:
                 results.append(f"* {opt['name']}")
-                if opt["description"]:
+                if opt.get("description"):
                     results.append(f"  {opt['description']}")
                 results.append("")
+            if len(matches) > 100:
+                results.append(f"... and {len(matches) - 100} more options")
             return "\n".join(results).strip()
         else:
-            options = parse_html_options(url, limit=5000)
             categories: dict[str, int] = {}
             for opt in options:
                 name = opt["name"]

--- a/mcp_nixos/sources/home_manager.py
+++ b/mcp_nixos/sources/home_manager.py
@@ -1,67 +1,102 @@
-"""Home Manager options source."""
+"""Home Manager options source.
 
-from ..config import HOME_MANAGER_URL
-from ..utils import error, parse_html_options
+The Home Manager docs migrated to an mdBook site in mid-2026. Options now
+live on ~600 per-page HTML files (one page per program / service / top-level
+category) instead of a single giant `options.xhtml`. The HomeManagerCache
+discovers those pages and parses out the options; this module is a thin
+formatter on top of it.
+"""
+
+from ..caches import home_manager_cache
+from ..config import APIError
+from ..utils import error
 
 
 def _search_home_manager(query: str, limit: int) -> str:
-    """Search Home Manager options by parsing HTML documentation."""
+    """Search Home Manager options by name or description substring."""
     try:
-        options = parse_html_options(HOME_MANAGER_URL, query, "", limit)
-        if not options:
-            return f"No Home Manager options found matching '{query}'"
-        results = [f"Found {len(options)} Home Manager options matching '{query}':\n"]
-        for opt in options:
-            results.append(f"* {opt['name']}")
-            if opt["type"]:
-                results.append(f"  Type: {opt['type']}")
-            if opt["description"]:
-                results.append(f"  {opt['description']}")
-            results.append("")
-        return "\n".join(results).strip()
+        options = home_manager_cache.get_options()
+    except APIError:
+        raise
     except Exception as e:
         return error(str(e))
+
+    query_lower = query.lower()
+    matches = []
+    for opt in options:
+        name = opt.get("name", "")
+        desc = opt.get("description", "")
+        if query_lower in name.lower() or query_lower in desc.lower():
+            matches.append(opt)
+            if len(matches) >= limit:
+                break
+
+    if not matches:
+        return f"No Home Manager options found matching '{query}'"
+
+    results = [f"Found {len(matches)} Home Manager options matching '{query}':\n"]
+    for opt in matches:
+        results.append(f"* {opt['name']}")
+        if opt.get("type"):
+            results.append(f"  Type: {opt['type']}")
+        if opt.get("description"):
+            results.append(f"  {opt['description']}")
+        results.append("")
+    return "\n".join(results).strip()
 
 
 def _info_home_manager(name: str) -> str:
     """Get detailed info for a Home Manager option."""
     try:
-        options = parse_html_options(HOME_MANAGER_URL, name, "", 100)
-        for opt in options:
-            if opt["name"] == name:
-                info = [f"Option: {name}"]
-                if opt["type"]:
-                    info.append(f"Type: {opt['type']}")
-                if opt["description"]:
-                    info.append(f"Description: {opt['description']}")
-                return "\n".join(info)
-
-        if options:
-            suggestions = [opt["name"] for opt in options[:5] if name in opt["name"]]
-            if suggestions:
-                return error(f"Option '{name}' not found. Similar: {', '.join(suggestions)}", "NOT_FOUND")
-        return error(f"Option '{name}' not found", "NOT_FOUND")
+        opt = home_manager_cache.get_by_name(name)
+    except APIError:
+        raise
     except Exception as e:
         return error(str(e))
+
+    if opt is not None:
+        info = [f"Option: {name}"]
+        if opt.get("type"):
+            info.append(f"Type: {opt['type']}")
+        if opt.get("description"):
+            info.append(f"Description: {opt['description']}")
+        if opt.get("default"):
+            info.append(f"Default: {opt['default']}")
+        if opt.get("example"):
+            info.append(f"Example: {opt['example']}")
+        return "\n".join(info)
+
+    # Not found — offer up to 5 substring suggestions so the caller can retry.
+    try:
+        options = home_manager_cache.get_options()
+    except APIError:
+        options = []
+    suggestions = [o["name"] for o in options if name in o.get("name", "")][:5]
+    if suggestions:
+        return error(f"Option '{name}' not found. Similar: {', '.join(suggestions)}", "NOT_FOUND")
+    return error(f"Option '{name}' not found", "NOT_FOUND")
 
 
 def _stats_home_manager() -> str:
     """Get Home Manager option counts and top categories."""
     try:
-        options = parse_html_options(HOME_MANAGER_URL, limit=5000)
-        if not options:
-            return error("Failed to fetch Home Manager statistics")
-
-        categories: dict[str, int] = {}
-        for opt in options:
-            cat = opt["name"].split(".")[0]
-            categories[cat] = categories.get(cat, 0) + 1
-
-        top_cats = sorted(categories.items(), key=lambda x: x[1], reverse=True)[:5]
-        result = ["Home Manager Statistics:", f"* Total options: {len(options):,}", f"* Categories: {len(categories)}"]
-        result.append("* Top categories:")
-        for cat, count in top_cats:
-            result.append(f"  - {cat}: {count:,}")
-        return "\n".join(result)
+        options = home_manager_cache.get_options()
+    except APIError:
+        raise
     except Exception as e:
         return error(str(e))
+
+    if not options:
+        return error("Failed to fetch Home Manager statistics")
+
+    categories: dict[str, int] = {}
+    for opt in options:
+        cat = opt["name"].split(".")[0]
+        categories[cat] = categories.get(cat, 0) + 1
+
+    top_cats = sorted(categories.items(), key=lambda x: x[1], reverse=True)[:5]
+    result = ["Home Manager Statistics:", f"* Total options: {len(options):,}", f"* Categories: {len(categories)}"]
+    result.append("* Top categories:")
+    for cat, count in top_cats:
+        result.append(f"  - {cat}: {count:,}")
+    return "\n".join(result)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -855,16 +855,31 @@ class TestNooglePlainTextOutput:
 class TestHomeManagerCache:
     """Test HomeManagerCache (issue #172)."""
 
+    @pytest.fixture
+    def fresh_cache(self, monkeypatch):
+        """Reset the module-level home_manager_cache singleton and restore it
+        after the test so we don't leak state into other tests."""
+        from mcp_nixos import caches
+
+        original = caches.home_manager_cache
+        cache = caches.HomeManagerCache()
+        monkeypatch.setattr(caches, "home_manager_cache", cache)
+        yield cache
+        monkeypatch.setattr(caches, "home_manager_cache", original)
+
     def _fresh_cache(self):
-        """Reset the module-level home_manager_cache singleton."""
+        """Convenience wrapper: build a fresh cache without using monkeypatch.
+        Use the `fresh_cache` fixture in new tests so the module-level
+        singleton is restored on teardown.
+        """
         from mcp_nixos import caches
 
         caches.home_manager_cache = caches.HomeManagerCache()
         return caches.home_manager_cache
 
-    def _page_resp(self, html: str):
+    def _page_resp(self, html: str, status: int = 200):
         """Build a Mock response carrying the given HTML body."""
-        resp = Mock(status_code=200, raise_for_status=Mock())
+        resp = Mock(status_code=status, raise_for_status=Mock())
         resp.content = html.encode("utf-8")
         return resp
 
@@ -1064,3 +1079,153 @@ class TestHomeManagerCache:
         assert names == ["a.b", "c.d"]
         # 3 listings + 2 page fetches = 5 calls (other listings empty).
         assert mock_get.call_count == 5
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_options_listing_failure_raises(self, mock_get):
+        """A non-2xx response from a listing raises APIError, not silent
+        partial-best-effort. (Review feedback on PR #174.)"""
+        from mcp_nixos.caches import APIError
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp('<html><body><a href="a.html">a</a></body></html>')
+            if url.endswith("/programs/"):
+                # Simulate transient upstream issue.
+                return self._page_resp("", status=502)
+            if url.endswith("/services/"):
+                return self._page_resp("<html><body></body></html>")
+            if url.endswith("a.html"):
+                return self._page_resp(
+                    '<html><body><main><h2 id="opt-a.b"><a>a.b</a></h2><p>desc</p></main></body></html>'
+                )
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "Failed to fetch Home Manager option listings" in str(exc_info.value)
+        assert "HTTP 502" in str(exc_info.value)
+        # Nothing should be cached on failure.
+        assert cache.options is None
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_options_rejects_off_host_href(self, mock_get):
+        """An href that resolves to a different host is ignored (SSRF guard)."""
+        # Top-level listing contains one safe link and one cross-origin link.
+        listing_html = (
+            "<html><body>"
+            '<a href="good.html">good</a>'
+            '<a href="https://evil.example.com/steal.html">evil</a>'
+            "</body></html>"
+        )
+        empty_listing = "<html><body></body></html>"
+        page_good = '<html><body><main><h2 id="opt-good.name"><a>good.name</a></h2><p>desc</p></main></body></html>'
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("good.html"):
+                return self._page_resp(page_good)
+            raise AssertionError(f"Cross-origin URL slipped past SSRF guard: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+        names = [o["name"] for o in options]
+        assert names == ["good.name"]
+        # The evil URL must not have been requested.
+        assert mock_get.call_count == 4  # 3 listings + 1 page (not 5)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_concurrent_first_call_only_fetches_once(self, mock_get):
+        """Double-checked locking: N concurrent first calls run the walk
+        exactly once, not N times."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        listing_html = '<html><body><a href="a.html">a</a></body></html>'
+        empty_listing = "<html><body></body></html>"
+        page_a = '<html><body><main><h2 id="opt-a.b"><a>a.b</a></h2><p>desc</p></main></body></html>'
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("a.html"):
+                return self._page_resp(page_a)
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        # Provide enough responses for any number of walks.
+        mock_get.side_effect = [
+            self._page_resp(listing_html),
+            self._page_resp(empty_listing),
+            self._page_resp(empty_listing),
+            self._page_resp(page_a),
+        ] * 50
+
+        cache = self._fresh_cache()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: cache.get_options(), range(20)))
+
+        # Exactly one walk: 3 listings + 1 page = 4 network calls.
+        assert mock_get.call_count == 4
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_options_are_sorted_by_name(self, mock_get):
+        """`all_options` is sorted by name for deterministic downstream
+        output (review feedback on PR #174)."""
+        listing_html = """
+        <html><body>
+            <a href="z.html">z</a>
+            <a href="a.html">a</a>
+        </body></html>
+        """
+        empty_listing = "<html><body></body></html>"
+        page_z = '<html><body><main><h2 id="opt-z.last"><a>z.last</a></h2><p>z</p></main></body></html>'
+        page_a = (
+            "<html><body><main>"
+            '<h2 id="opt-a.first"><a>a.first</a></h2><p>a</p>'
+            '<h2 id="opt-a.second"><a>a.second</a></h2><p>a</p>'
+            "</main></body></html>"
+        )
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("z.html"):
+                return self._page_resp(page_z)
+            if url.endswith("a.html"):
+                return self._page_resp(page_a)
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+        names = [o["name"] for o in options]
+        assert names == ["a.first", "a.second", "z.last"]
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_type_label_without_colon(self, mock_get):
+        """The Type label can be parsed even if the trailing colon is missing
+        (review feedback on PR #174)."""
+        from mcp_nixos.caches import HomeManagerCache
+
+        html = """
+        <html><body><main>
+            <h2 id="opt-services.foo.bar"><a>services.foo.bar</a></h2>
+            <p>desc</p>
+            <p><em>Type</em> string (no colon after the label)</p>
+        </main></body></html>
+        """
+        mock_get.return_value = self._page_resp(html)
+
+        options = HomeManagerCache._fetch_page_options("http://stub/page.html")
+        assert options[0]["type"] == "string (no colon after the label)"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -849,3 +849,218 @@ class TestNooglePlainTextOutput:
         assert "<error>" not in result
         assert "</error>" not in result
         assert not result.strip().startswith("{")
+
+
+@pytest.mark.unit
+class TestHomeManagerCache:
+    """Test HomeManagerCache (issue #172)."""
+
+    def _fresh_cache(self):
+        """Reset the module-level home_manager_cache singleton."""
+        from mcp_nixos import caches
+
+        caches.home_manager_cache = caches.HomeManagerCache()
+        return caches.home_manager_cache
+
+    def _page_resp(self, html: str):
+        """Build a Mock response carrying the given HTML body."""
+        resp = Mock(status_code=200, raise_for_status=Mock())
+        resp.content = html.encode("utf-8")
+        return resp
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_options_via_mock(self, mock_get):
+        """Mocked HTTP: parse a single page with full option block."""
+        from mcp_nixos.caches import HomeManagerCache
+
+        html = """
+        <html><body><main>
+            <h2 id="opt-programs.git.enable"><a href="#opt-programs.git.enable">programs.git.enable</a></h2>
+            <p>Whether to enable Git.</p>
+            <p><em>Type:</em> boolean</p>
+            <p><em>Default:</em></p>
+            <pre><code>false</code></pre>
+            <p><em>Example:</em></p>
+            <pre><code>true</code></pre>
+            <h2 id="opt-programs.git.package"><a href="#opt-programs.git.package">programs.git.package</a></h2>
+            <p>The git package to use.</p>
+            <p><em>Type:</em> null or package</p>
+        </main></body></html>
+        """
+        mock_get.return_value = self._page_resp(html)
+
+        options = HomeManagerCache._fetch_page_options("http://stub/page.html")
+        assert len(options) == 2
+
+        enable = options[0]
+        assert enable["name"] == "programs.git.enable"
+        assert enable["type"] == "boolean"
+        assert enable["description"] == "Whether to enable Git."
+        assert enable["default"] == "false"
+        assert enable["example"] == "true"
+
+        package = options[1]
+        assert package["name"] == "programs.git.package"
+        assert package["type"] == "null or package"
+        assert package["default"] == ""  # no Default: block
+        assert package["example"] == ""
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_options_skips_non_option_h2(self, mock_get):
+        """A non opt- h2 is ignored; multi-paragraph description is joined."""
+        from mcp_nixos.caches import HomeManagerCache
+
+        html = """
+        <html><body><main>
+            <h2 id="not-an-option">Section heading</h2>
+            <p>Should be ignored.</p>
+            <h2 id="opt-services.foo.bar"><a href="#opt-services.foo.bar">services.foo.bar</a></h2>
+            <p>First paragraph.</p>
+            <p>Second paragraph.</p>
+            <p><em>Type:</em> string</p>
+        </main></body></html>
+        """
+        mock_get.return_value = self._page_resp(html)
+
+        options = HomeManagerCache._fetch_page_options("http://stub/page.html")
+        assert len(options) == 1
+        assert options[0]["name"] == "services.foo.bar"
+        assert options[0]["type"] == "string"
+        assert "First paragraph." in options[0]["description"]
+        assert "Second paragraph." in options[0]["description"]
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_options_skips_h2_without_dot(self, mock_get):
+        """Anchor ids without a dot are not valid option names; skip them."""
+        from mcp_nixos.caches import HomeManagerCache
+
+        html = """
+        <html><body><main>
+            <h2 id="opt-badname"><a>badname</a></h2>
+            <p>Should be skipped.</p>
+            <h2 id="opt-good.name"><a>good.name</a></h2>
+            <p>Should be kept.</p>
+        </main></body></html>
+        """
+        mock_get.return_value = self._page_resp(html)
+
+        options = HomeManagerCache._fetch_page_options("http://stub/page.html")
+        assert [o["name"] for o in options] == ["good.name"]
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_by_name_after_load(self, mock_get):
+        """get_by_name returns the matching option after the cache is loaded."""
+        # The cache makes 3 listing requests (top-level, programs/, services/)
+        # plus one fetch per discovered page. The first listing returns a link
+        # to git.html; the rest are empty; the page is fetched last.
+        listing_html = '<html><body><a href="git.html">git</a></body></html>'
+        empty_listing = "<html><body></body></html>"
+        page_html = """
+        <html><body><main>
+            <h2 id="opt-programs.git.enable"><a>programs.git.enable</a></h2>
+            <p>Enable git.</p>
+            <p><em>Type:</em> boolean</p>
+        </main></body></html>
+        """
+
+        # First three responses are the three listings; the fourth is the page
+        # fetch. The fetch order is deterministic (listings are sequential),
+        # but we use side_effect as a callable so we can match by URL.
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("git.html"):
+                return self._page_resp(page_html)
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        cache.get_options()
+        opt = cache.get_by_name("programs.git.enable")
+        assert opt is not None
+        assert opt["type"] == "boolean"
+        assert opt["description"] == "Enable git."
+
+        # Second lookup is cached (no extra HTTP call).
+        calls_after_first_load = mock_get.call_count
+        cache.get_by_name("programs.git.enable")
+        assert mock_get.call_count == calls_after_first_load
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_by_name_unknown_returns_none(self, mock_get):
+        """get_by_name returns None for a name not in the cache (after load)."""
+        # One page discovered, containing a single option; lookups for any
+        # other name should return None.
+        listing_html = '<html><body><a href="a.html">a</a></body></html>'
+        empty_listing = "<html><body></body></html>"
+        page_a = '<html><body><main><h2 id="opt-a.b"><a>a.b</a></h2><p>desc</p></main></body></html>'
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("a.html"):
+                return self._page_resp(page_a)
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        cache.get_options()
+        assert cache.get_by_name("a.b") is not None
+        assert cache.get_by_name("does.not.exist") is None
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_options_empty_listing_raises(self, mock_get):
+        """If no pages are discovered, get_options raises APIError."""
+        from mcp_nixos.caches import APIError
+
+        # All three listings return empty bodies — no links to follow.
+        empty_listing = "<html><body></body></html>"
+
+        def fake_get(url, **_kwargs):
+            return self._page_resp(empty_listing)
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_options()
+        assert "No Home Manager option pages" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_options_uses_thread_pool(self, mock_get):
+        """get_options fans out fetches across the thread pool."""
+        listing_html = """
+        <html><body>
+            <a href="a.html">a</a>
+            <a href="b.html">b</a>
+        </body></html>
+        """
+        empty_listing = "<html><body></body></html>"
+        page_a = '<html><body><main><h2 id="opt-a.b"><a>a.b</a></h2><p>desc</p></main></body></html>'
+        page_b = '<html><body><main><h2 id="opt-c.d"><a>c.d</a></h2><p>desc</p></main></body></html>'
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/options/home-manager/"):
+                return self._page_resp(listing_html)
+            if url.endswith("/programs/") or url.endswith("/services/"):
+                return self._page_resp(empty_listing)
+            if url.endswith("a.html"):
+                return self._page_resp(page_a)
+            if url.endswith("b.html"):
+                return self._page_resp(page_b)
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        options = cache.get_options()
+        names = sorted(o["name"] for o in options)
+        assert names == ["a.b", "c.d"]
+        # 3 listings + 2 page fetches = 5 calls (other listings empty).
+        assert mock_get.call_count == 5


### PR DESCRIPTION
Closes #172.

> **Draft PR** — happy to iterate on review feedback. The big surfaces here
> are the parser, the page-discovery strategy, and the cold-start cost.

## What broke

The home-manager docs migrated to an mdBook site in mid-2026. The legacy
single-page \`options.xhtml\` is now a 1.4 KB JS redirect stub. The
\`parse_html_options\` helper in \`utils.py\` (built for the old
Pandoc-style \`<dt>/<dd>\` xhtml) returns 0 options for every query,
so the MCP \`home-manager\` source has been silently broken since the
redesign.

## New layout

Options are now split across ~600 per-page HTML files:

- \`options/home-manager/\` → ~30 top-level pages (accounts.html, dconf.html, fonts.html, gtk.html, …)
- \`options/home-manager/programs/\` → ~400 program pages (git.html, helix.html, …)
- \`options/home-manager/services/\` → ~170 service pages

Each page is a self-contained mdBook chapter with options as
\`<h2 id="opt-...">\` headers followed by \`<p>\` blocks for the
description, type, default, and example.

## What changed

- New \`HomeManagerCache\` (\`mcp_nixos/caches.py\`) that:
  - Discovers page URLs by walking the three directory listings.
  - Fetches each page in parallel via a 10-worker \`ThreadPoolExecutor\`.
  - Parses options into a single in-memory list (~5,480 options total).
  - Exposes \`get_options()\` and \`get_by_name()\` for search/info.
  - Raises \`APIError\` if no pages are discovered — no more silent
    "0 options" on a wrong URL.
- \`home_manager.py\` and \`base._browse_options\` now read from the cache
  instead of \`parse_html_options\`.
- \`HOME_MANAGER_URL\` points at the new top-level redirect target for
  backward compatibility; new \`HOME_MANAGER_BASE_URL\` /
  \`HOME_MANAGER_OPTIONS_DIR\` constants are exported for downstream use.
- \`tests/test_server.py\` — 7 new unit tests covering page discovery,
  per-page parsing (basic, multi-paragraph, non-option \`<h2>\` skip,
  no-dot-name skip), the thread-pool fan-out, the empty-listing error
  path, and \`get_by_name\` cache reuse.

## Cold-start cost

A fresh process makes ~600 HTTP requests to GitHub Pages on the first
\`home-manager\` call (~18s on a warm cache with 10 workers).
Subsequent calls are O(1) from in-memory state. If GitHub Pages
rate-limits during a cold start, the \`APIError\` is surfaced clearly.

## Alternative considered

Pulling the 14.9 MB \`searchindex.js\` to enumerate options without
fetching pages. Rejected because (a) the file is much larger than the
total page payload (~18 MB), (b) it still requires a per-option page
fetch for full descriptions, (c) the file's URL includes a content
hash that's awkward to discover at startup. The directory-listing
approach is 3 small requests + on-demand page fetches.

## Verified

- 235 unit tests pass on this branch.
- \`ruff check\`, \`ruff format --check\`, and \`mypy\` are clean.
- Live end-to-end via the MCP \`nix\` tool:
  - \`action=search source=home-manager query=git\` returns expected matches.
  - \`action=info source=home-manager query=programs.git.signing.format\`
    returns type / description / default.
  - \`action=stats source=home-manager\` reports 5,480 total options across
    29 categories (top: programs 3,173 / services 1,112 / accounts 289).
  - \`action=browse source=home-manager query=programs.git\` lists 15 options
    under that prefix.

Work created during Nix Taco Sprint: https://tacosprint.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home Manager options are now cached in memory for faster lookups and searches, improving overall performance and responsiveness.
  * Enhanced option discovery and matching with support for prefix-based browsing.

* **Tests**
  * Added comprehensive test coverage for cache functionality and option parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->