### PR TITLE
fix(channels): add 26.05 to FALLBACK_CHANNELS and probe higher generations

### DIFF
--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -36,7 +36,11 @@ class ChannelCache:
         return self.resolved_channels if self.resolved_channels is not None else {}
 
     def _discover_available_channels(self) -> dict[str, str]:
-        generations = [43, 44, 45, 46]
+        # Generations 43-48 cover the 25.05 → 26.05 window. Bump this list
+        # when Hydra publishes a new generation; the better fix is the
+        # `_cat/aliases` discovery in PR #159, but this hardcoded probe
+        # remains the fallback for the index path.
+        generations = [43, 44, 45, 46, 47, 48]
         versions = ["unstable", "25.05", "25.11", "26.05", "26.11"]
         available = {}
         for gen in generations:

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -20,15 +20,19 @@ BASE_CHANNELS = {
     "unstable": "nixos-unstable",
     "25.05": "nixos-25.05",
     "25.11": "nixos-25.11",
+    "26.05": "nixos-26.05",
 }
 
-# Fallback channels when API discovery fails (static mappings based on recent patterns)
+# Fallback channels when API discovery fails (static mappings based on recent patterns).
+# `stable` always aliases to the most recent release — bump this on each new
+# NixOS release so users on the fallback path still hit a live index.
 FALLBACK_CHANNELS = {
     "unstable": "latest-44-nixos-unstable",
-    "stable": "latest-44-nixos-25.11",
+    "stable": "latest-44-nixos-26.05",
     "25.05": "latest-44-nixos-25.05",
     "25.11": "latest-44-nixos-25.11",
-    "beta": "latest-44-nixos-25.11",
+    "26.05": "latest-44-nixos-26.05",
+    "beta": "latest-44-nixos-26.05",
 }
 
 HOME_MANAGER_URL = "https://nix-community.github.io/home-manager/options.xhtml"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,6 +168,14 @@ class TestChannelCache:
         assert cache.using_fallback is True
         assert "unstable" in result
 
+    def test_resolved_channels_fallback_includes_26_05(self):
+        """The 26.05 channel (current stable) must be reachable via the fallback
+        path — see issue #166."""
+        from mcp_nixos.config import FALLBACK_CHANNELS
+
+        assert "26.05" in FALLBACK_CHANNELS
+        assert FALLBACK_CHANNELS["stable"] == FALLBACK_CHANNELS["26.05"]
+
     @patch("mcp_nixos.sources.base.requests.post")
     def test_discover_channels(self, mock_post):
         mock_resp = Mock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,6 +168,7 @@ class TestChannelCache:
         assert cache.using_fallback is True
         assert "unstable" in result
 
+    @pytest.mark.unit
     def test_resolved_channels_fallback_includes_26_05(self):
         """The 26.05 channel (current stable) must be reachable via the fallback
         path — see issue #166."""


### PR DESCRIPTION
Closes #166.

## What broke

\`channel=26.05\` returned \`Invalid channel '26.05'\` even though
\`ChannelCache._discover_available_channels\` already probed 26.05.
The reason: when \`search.nixos.org\` is unreachable (e.g. during a
backend outage), \`get_resolved()\` falls back to \`FALLBACK_CHANNELS\`,
which only listed up to 25.11.

## What changed

- \`mcp_nixos/config.py\` — \`BASE_CHANNELS\` and \`FALLBACK_CHANNELS\`
  now include \`26.05\`. \`stable\` and \`beta\` both alias to the
  26.05 index. \`25.05\` and \`25.11\` are still in the fallback so
  users on older channels aren't broken.
- \`mcp_nixos/caches.py\` — widen the hardcoded generation list in
  \`ChannelCache._discover_available_channels\` from 43-46 to 43-48 so
  the discovery probe keeps up with Hydra rollovers while we wait for
  PR #159 to land.
- \`tests/test_server.py\` — new
  \`test_resolved_channels_fallback_includes_26_05\` asserts the 26.05
  entry is present and that \`stable\` aliases to it.

## Relationship to PR #159

PR #159 (ningw42) is a more thorough rewrite of the channel discovery
loop that uses \`_cat/aliases\` to dynamically discover every live
generation, instead of probing a hardcoded range. This PR is
intentionally narrow: it makes the *fallback* path include 26.05 so
users on the offline path (which the index path never exercises)
aren't blocked. When #159 lands, the hardcoded list in
\`_discover_available_channels\` can be removed; the \`FALLBACK_CHANNELS\`
update is independent and useful either way.

## Verified

- 235 unit tests pass.
- \`ruff check\`, \`ruff format --check\`, and \`mypy\` are clean.
- \`FALLBACK_CHANNELS['26.05'] == 'latest-44-nixos-26.05'\` and
  \`FALLBACK_CHANNELS['stable'] == 'latest-44-nixos-26.05'\`.

Work created during Nix Taco Sprint: https://tacosprint.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Extended channel discovery to probe newer NixOS generations (now including 47–48), improving detection coverage for newer releases.
  * Updated default fallback channels to use the NixOS 26.05 release index, including an explicit 26.05 mapping.
* **Tests**
  * Added a unit test to confirm the fallback configuration includes 26.05 and that the stable fallback matches the 26.05 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->