### PR TITLE
feat(den): add Den framework docs as a new MCP source

### DIFF
--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -377,16 +377,15 @@ class DenCache:
 
         # Body: prefer the <main data-pagefind-body> element Starlight emits
         # for Pagefind; fall back to the first <main> if the attribute is
-        # missing (older Starlight, or a future redesign). We use a CSS
-        # selector for the inner div because the BeautifulSoup stubs narrow
-        # `select_one`'s return type to `Tag | None`, which avoids the
-        # `Tag | NavigableString | int` union mypy complains about.
+        # missing (older Starlight, or a future redesign). We use CSS
+        # selectors throughout so the BeautifulSoup stubs narrow the return
+        # types to `Tag | None`, which avoids the `Tag | NavigableString | int`
+        # union mypy complains about.
         body = ""
-        for main in soup.find_all("main"):
-            if main.attrs.get("data-pagefind-body") is not None or True:
-                main_div = main.select_one("div.sl-markdown-content")
-                body = main_div.get_text("\n", strip=True) if main_div is not None else main.get_text("\n", strip=True)
-                break
+        main = soup.select_one("main[data-pagefind-body]") or soup.select_one("main")
+        if main is not None:
+            main_div = main.select_one("div.sl-markdown-content")
+            body = main_div.get_text("\n", strip=True) if main_div is not None else main.get_text("\n", strip=True)
 
         return {"path": path, "url": url, "title": title, "body": body}
 

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -344,10 +344,8 @@ class DenCache:
             # Skip anchors, external links, and trailing-slash-only links.
             if not href.startswith("/"):
                 continue
-            # Normalize: strip fragments, ensure trailing slash.
-            href = href.split("#", 1)[0]
-            if not href.endswith("/"):
-                href = href + "/"
+            # Normalize to a canonical `/foo/bar/` path (drops query/fragment, unquotes, collapses `//`, ensures trailing slash).
+            href = self._normalize_path(href)
             if not any(href.startswith(p) for p in self._DOC_PATH_PREFIXES):
                 continue
             if href in seen:

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -246,7 +246,7 @@ class DenCache:
 
     1. **Discovery** — fetch the `/overview/` page once. Its sidebar links
        to every doc page; we extract the `/explanation/|/guides/|/reference/
-       |/tutorials/|/motivation/|/maintainers/` paths.
+       |/tutorials/|/motivation/|/maintainers/|/overview/` paths.
     2. **Parallel fetch** — fetch each page in a bounded thread pool
        (10 workers), parse the title (`<h1 id="_top">`) and the
        `<main data-pagefind-body>` body, strip HTML to plain text.
@@ -296,23 +296,22 @@ class DenCache:
                 raise APIError("No Den docs paths discovered from /overview/")
 
             all_pages: list[dict[str, Any]] = []
-            try:
-                with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
-                    futures = {pool.submit(self._fetch_page, path): path for path in paths}
-                    for future in as_completed(futures):
-                        path = futures[future]
-                        try:
-                            page = future.result()
-                        except requests.RequestException as exc:
-                            raise APIError(f"Failed to fetch Den page {path}: {exc}") from exc
-                        except Exception as exc:
-                            raise APIError(f"Failed to parse Den page {path}: {exc}") from exc
-                        if page is not None:
-                            all_pages.append(page)
-            except requests.Timeout as exc:
-                raise APIError("Timeout fetching Den docs") from exc
-            except requests.RequestException as exc:
-                raise APIError(f"Failed to fetch Den docs: {exc}") from exc
+            # `future.result()` re-raises whatever `_fetch_page` raised in its
+            # worker thread; we wrap those per-page (a Timeout is a
+            # RequestException, so it's covered too). Nothing else inside the
+            # pool block raises a `requests` error, so no outer handler is needed.
+            with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
+                futures = {pool.submit(self._fetch_page, path): path for path in paths}
+                for future in as_completed(futures):
+                    path = futures[future]
+                    try:
+                        page = future.result()
+                    except requests.RequestException as exc:
+                        raise APIError(f"Failed to fetch Den page {path}: {exc}") from exc
+                    except Exception as exc:
+                        raise APIError(f"Failed to parse Den page {path}: {exc}") from exc
+                    if page is not None:
+                        all_pages.append(page)
 
             # Sort by path for deterministic downstream output (search, info,
             # browse) — `as_completed()` yields in completion order.
@@ -344,7 +343,8 @@ class DenCache:
             # Skip anchors, external links, and trailing-slash-only links.
             if not href.startswith("/"):
                 continue
-            # Normalize to a canonical `/foo/bar/` path (drops query/fragment, unquotes, collapses `//`, ensures trailing slash).
+            # Normalize to a canonical `/foo/bar/` path (drops query/fragment,
+            # unquotes, collapses `//`, ensures trailing slash).
             href = self._normalize_path(href)
             if not any(href.startswith(p) for p in self._DOC_PATH_PREFIXES):
                 continue

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -2,11 +2,15 @@
 
 import json
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import requests
+from bs4 import BeautifulSoup
 
 from .config import (
+    DEN_BASE_URL,
+    DEN_OVERVIEW_URL,
     FALLBACK_CHANNELS,
     NIXDEV_SEARCH_INDEX,
     NIXOS_API,
@@ -229,3 +233,168 @@ class NoogleCache:
 
 
 noogle_cache = NoogleCache()
+
+
+class DenCache:
+    """Cache for Den framework docs (https://den.denful.dev).
+
+    The Den site is built with Starlight (Astro 5). The site exposes no
+    `sitemap.xml` and no Pagefind JSON metadata (the Pagefind index is a
+    bincode binary that needs WASM to read), so the loader does its own
+    walk:
+
+    1. **Discovery** — fetch the `/overview/` page once. Its sidebar links
+       to every doc page; we extract the `/explanation/|/guides/|/reference/
+       |/tutorials/|/motivation/|/maintainers/` paths.
+    2. **Parallel fetch** — fetch each page in a bounded thread pool
+       (10 workers), parse the title (`<h1 id="_top">`) and the
+       `<main data-pagefind-body>` body, strip HTML to plain text.
+    3. **Index** — hold a flat in-memory `pages: list[dict]` plus a
+       `by_path: dict[str, dict]` for exact lookups by `/path/`.
+
+    Total payload is small (≈50 pages × a few KB each) so the in-memory
+    copy is cheap. The full walk happens once per process; subsequent
+    search/info/browse calls are O(n) over the cached list.
+    """
+
+    # Path prefixes we consider "doc pages" (vs. meta pages like
+    # `/community/`, `/contributing/`, `/releases/`, `/`, etc.).
+    _DOC_PATH_PREFIXES = (
+        "/explanation/",
+        "/guides/",
+        "/reference/",
+        "/tutorials/",
+        "/motivation/",
+        "/maintainers/",
+        "/overview/",
+    )
+
+    _MAX_WORKERS = 10
+
+    def __init__(self) -> None:
+        self.pages: list[dict[str, Any]] | None = None
+        self._by_path: dict[str, dict[str, Any]] | None = None
+
+    def get_pages(self) -> list[dict[str, Any]]:
+        """Fetch and cache all Den doc pages."""
+        if self.pages is not None:
+            return self.pages
+
+        paths = self._discover_paths()
+        if not paths:
+            raise APIError("No Den docs paths discovered from /overview/")
+
+        all_pages: list[dict[str, Any]] = []
+        try:
+            with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
+                futures = {pool.submit(self._fetch_page, path): path for path in paths}
+                for future in as_completed(futures):
+                    path = futures[future]
+                    try:
+                        page = future.result()
+                    except requests.RequestException as exc:
+                        raise APIError(f"Failed to fetch Den page {path}: {exc}") from exc
+                    except Exception as exc:
+                        raise APIError(f"Failed to parse Den page {path}: {exc}") from exc
+                    if page is not None:
+                        all_pages.append(page)
+        except requests.Timeout as exc:
+            raise APIError("Timeout fetching Den docs") from exc
+        except requests.RequestException as exc:
+            raise APIError(f"Failed to fetch Den docs: {exc}") from exc
+
+        # Sort by path for deterministic output.
+        all_pages.sort(key=lambda p: p.get("path", ""))
+        self.pages = all_pages
+        self._by_path = {p["path"]: p for p in all_pages if p.get("path")}
+        return self.pages
+
+    def get_by_path(self, path: str) -> dict[str, Any] | None:
+        """Look up a page by its canonical `/path/` (with trailing slash)."""
+        if self._by_path is None:
+            self.get_pages()
+        return self._by_path.get(self._normalize_path(path)) if self._by_path else None
+
+    def _discover_paths(self) -> list[str]:
+        """Read `/overview/` and return unique doc paths in document order."""
+        try:
+            resp = requests.get(DEN_OVERVIEW_URL, timeout=15)
+        except requests.RequestException as exc:
+            raise APIError(f"Failed to fetch Den overview: {exc}") from exc
+        if resp.status_code != 200:
+            raise APIError(f"Den overview returned HTTP {resp.status_code} (expected 200)")
+
+        soup = BeautifulSoup(resp.content, "html.parser")
+        seen: set[str] = set()
+        paths: list[str] = []
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            # Skip anchors, external links, and trailing-slash-only links.
+            if not href.startswith("/"):
+                continue
+            # Normalize: strip fragments, ensure trailing slash.
+            href = href.split("#", 1)[0]
+            if not href.endswith("/"):
+                href = href + "/"
+            if not any(href.startswith(p) for p in self._DOC_PATH_PREFIXES):
+                continue
+            if href in seen:
+                continue
+            seen.add(href)
+            paths.append(href)
+        return paths
+
+    @staticmethod
+    def _fetch_page(path: str) -> dict[str, Any] | None:
+        """Fetch a single Den page and extract title + body.
+
+        Returns None for non-2xx responses (e.g., a path the overview linked
+        to that no longer exists). Skips silently so a single broken page
+        doesn't take the whole cache down.
+        """
+        url = f"{DEN_BASE_URL}{path}"
+        resp = requests.get(url, timeout=15)
+        if not resp.ok:
+            return None
+        soup = BeautifulSoup(resp.content, "html.parser")
+
+        # Title: <h1 id="_top"> on every Starlight page.
+        h1 = soup.find("h1", id="_top")
+        title = h1.get_text(strip=True) if h1 else path.strip("/").replace("-", " ").title()
+
+        # Body: <main data-pagefind-body> ... <div class="sl-markdown-content">.
+        body = ""
+        for elem in soup.find_all("main"):
+            if elem.attrs.get("data-pagefind-body") is not None or True:
+                # Starlight pages have a single <main data-pagefind-body>;
+                # fall back to the first <main> if the attribute is missing.
+                main_div = elem.find("div", class_="sl-markdown-content")
+                body = (main_div if main_div is not None else elem).get_text("\n", strip=True)
+                break
+
+        return {"path": path, "url": url, "title": title, "body": body}
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """Canonicalize a path to `/foo/bar/` form for by-path lookup."""
+        from urllib.parse import unquote
+
+        path = unquote(path.strip())
+        # Strip a leading base URL if present.
+        if path.startswith(DEN_BASE_URL):
+            path = path[len(DEN_BASE_URL) :]
+        # Drop query/fragment.
+        for sep in ("?", "#"):
+            if sep in path:
+                path = path.split(sep, 1)[0]
+        if not path.startswith("/"):
+            path = "/" + path
+        if not path.endswith("/"):
+            path = path + "/"
+        # Strip duplicate slashes (defensive).
+        while "//" in path:
+            path = path.replace("//", "/")
+        return path
+
+
+den_cache = DenCache()

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -274,40 +275,51 @@ class DenCache:
     def __init__(self) -> None:
         self.pages: list[dict[str, Any]] | None = None
         self._by_path: dict[str, dict[str, Any]] | None = None
+        self._init_lock = threading.Lock()
 
     def get_pages(self) -> list[dict[str, Any]]:
-        """Fetch and cache all Den doc pages."""
+        """Fetch and cache all Den doc pages.
+
+        Concurrency-safe via double-checked locking: N concurrent first
+        callers all see the cold cache, but only one performs the walk;
+        the rest wait and consume the cached list.
+        """
         if self.pages is not None:
             return self.pages
 
-        paths = self._discover_paths()
-        if not paths:
-            raise APIError("No Den docs paths discovered from /overview/")
+        with self._init_lock:
+            if self.pages is not None:
+                return self.pages
 
-        all_pages: list[dict[str, Any]] = []
-        try:
-            with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
-                futures = {pool.submit(self._fetch_page, path): path for path in paths}
-                for future in as_completed(futures):
-                    path = futures[future]
-                    try:
-                        page = future.result()
-                    except requests.RequestException as exc:
-                        raise APIError(f"Failed to fetch Den page {path}: {exc}") from exc
-                    except Exception as exc:
-                        raise APIError(f"Failed to parse Den page {path}: {exc}") from exc
-                    if page is not None:
-                        all_pages.append(page)
-        except requests.Timeout as exc:
-            raise APIError("Timeout fetching Den docs") from exc
-        except requests.RequestException as exc:
-            raise APIError(f"Failed to fetch Den docs: {exc}") from exc
+            paths = self._discover_paths()
+            if not paths:
+                raise APIError("No Den docs paths discovered from /overview/")
 
-        # Sort by path for deterministic output.
-        all_pages.sort(key=lambda p: p.get("path", ""))
-        self.pages = all_pages
-        self._by_path = {p["path"]: p for p in all_pages if p.get("path")}
-        return self.pages
+            all_pages: list[dict[str, Any]] = []
+            try:
+                with ThreadPoolExecutor(max_workers=self._MAX_WORKERS) as pool:
+                    futures = {pool.submit(self._fetch_page, path): path for path in paths}
+                    for future in as_completed(futures):
+                        path = futures[future]
+                        try:
+                            page = future.result()
+                        except requests.RequestException as exc:
+                            raise APIError(f"Failed to fetch Den page {path}: {exc}") from exc
+                        except Exception as exc:
+                            raise APIError(f"Failed to parse Den page {path}: {exc}") from exc
+                        if page is not None:
+                            all_pages.append(page)
+            except requests.Timeout as exc:
+                raise APIError("Timeout fetching Den docs") from exc
+            except requests.RequestException as exc:
+                raise APIError(f"Failed to fetch Den docs: {exc}") from exc
+
+            # Sort by path for deterministic downstream output (search, info,
+            # browse) — `as_completed()` yields in completion order.
+            all_pages.sort(key=lambda p: p.get("path", ""))
+            self.pages = all_pages
+            self._by_path = {p["path"]: p for p in all_pages if p.get("path")}
+            return self.pages
 
     def get_by_path(self, path: str) -> dict[str, Any] | None:
         """Look up a page by its canonical `/path/` (with trailing slash)."""
@@ -348,28 +360,32 @@ class DenCache:
     def _fetch_page(path: str) -> dict[str, Any] | None:
         """Fetch a single Den page and extract title + body.
 
-        Returns None for non-2xx responses (e.g., a path the overview linked
-        to that no longer exists). Skips silently so a single broken page
-        doesn't take the whole cache down.
+        Returns None only for 404 / 410 (the linked page no longer exists).
+        Any other non-2xx response (5xx, 429, etc.) raises so a transient
+        upstream incident doesn't silently produce a partial index.
         """
         url = f"{DEN_BASE_URL}{path}"
         resp = requests.get(url, timeout=15)
-        if not resp.ok:
+        if resp.status_code in (404, 410):
             return None
+        resp.raise_for_status()
         soup = BeautifulSoup(resp.content, "html.parser")
 
         # Title: <h1 id="_top"> on every Starlight page.
         h1 = soup.find("h1", id="_top")
         title = h1.get_text(strip=True) if h1 else path.strip("/").replace("-", " ").title()
 
-        # Body: <main data-pagefind-body> ... <div class="sl-markdown-content">.
+        # Body: prefer the <main data-pagefind-body> element Starlight emits
+        # for Pagefind; fall back to the first <main> if the attribute is
+        # missing (older Starlight, or a future redesign). We use a CSS
+        # selector for the inner div because the BeautifulSoup stubs narrow
+        # `select_one`'s return type to `Tag | None`, which avoids the
+        # `Tag | NavigableString | int` union mypy complains about.
         body = ""
-        for elem in soup.find_all("main"):
-            if elem.attrs.get("data-pagefind-body") is not None or True:
-                # Starlight pages have a single <main data-pagefind-body>;
-                # fall back to the first <main> if the attribute is missing.
-                main_div = elem.find("div", class_="sl-markdown-content")
-                body = (main_div if main_div is not None else elem).get_text("\n", strip=True)
+        for main in soup.find_all("main"):
+            if main.attrs.get("data-pagefind-body") is not None or True:
+                main_div = main.select_one("div.sl-markdown-content")
+                body = main_div.get_text("\n", strip=True) if main_div is not None else main.get_text("\n", strip=True)
                 break
 
         return {"path": path, "url": url, "title": title, "body": body}

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -57,6 +57,13 @@ NOOGLE_API = "https://noogle.dev/api/v1/data"
 NIXHUB_API = "https://search.devbox.sh"
 CACHE_NIXOS_ORG = "https://cache.nixos.org"
 
+# Den framework docs (https://den.denful.dev) — Starlight-rendered Astro site.
+# The `/overview/` page doubles as a sitemap (its sidebar links to every doc
+# page); we use it to discover all doc paths before fetching bodies in
+# parallel. See `DenCache` for the full walk strategy.
+DEN_BASE_URL = "https://den.denful.dev"
+DEN_OVERVIEW_URL = f"{DEN_BASE_URL}/overview/"
+
 # Flake inputs constants
 # Maximum file size for reading (1MB)
 MAX_FILE_SIZE = 1024 * 1024
@@ -75,4 +82,5 @@ KNOWN_SOURCES = {
     "nix-dev",
     "noogle",
     "nixhub",
+    "den",
 }

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -23,10 +23,12 @@ from . import __version__
 # Import from our modules
 from .caches import (
     ChannelCache,
+    DenCache,
     NixDevCache,
     NixvimCache,
     NoogleCache,
     channel_cache,
+    den_cache,
     nixdev_cache,
     nixvim_cache,
     noogle_cache,
@@ -36,6 +38,8 @@ from .config import (
     CACHE_NIXOS_ORG,
     DARWIN_URL,
     DEFAULT_LINE_LIMIT,
+    DEN_BASE_URL,
+    DEN_OVERVIEW_URL,
     FALLBACK_CHANNELS,
     FLAKE_INDEX,
     FLAKEHUB_API,
@@ -56,6 +60,8 @@ from .config import (
     DocumentParseError,
 )
 from .sources import (
+    # Den
+    _browse_den,
     # Nixvim
     _browse_nixvim_options,
     # Noogle
@@ -83,6 +89,7 @@ from .sources import (
     _get_noogle_type_signature,
     # Darwin
     _info_darwin,
+    _info_den,
     # FlakeHub
     _info_flakehub,
     # Home Manager
@@ -99,6 +106,7 @@ from .sources import (
     _list_channels,
     _run_nix_command,
     _search_darwin,
+    _search_den,
     _search_flakehub,
     # Flakes
     _search_flakes,
@@ -111,6 +119,7 @@ from .sources import (
     _search_noogle,
     _search_wiki,
     _stats_darwin,
+    _stats_den,
     _stats_flakehub,
     _stats_flakes,
     _stats_home_manager,
@@ -147,17 +156,18 @@ from .utils import (
 _SERVER_INSTRUCTIONS = (
     "Use this server for any question about nixpkgs packages, NixOS / home-manager / "
     "nix-darwin / nixvim options, flakes, FlakeHub, channels, the binary cache, store "
-    "paths, or the NixOS wiki and nix.dev docs. It queries live APIs (search.nixos.org, "
-    "NixHub, FlakeHub, cache.nixos.org) and is faster and more current than `nix search`, "
-    "scraping search.nixos.org by hand, or running `gh api` against NixOS/nixpkgs.\n\n"
+    "paths, the NixOS wiki, nix.dev docs, or Den framework docs. It queries live APIs "
+    "(search.nixos.org, NixHub, FlakeHub, cache.nixos.org) and is faster and more current "
+    "than `nix search`, scraping search.nixos.org by hand, or running `gh api` against "
+    "NixOS/nixpkgs.\n\n"
     "Trigger on any mention of a Nix package name, attribute path, NixOS / "
     "home-manager / darwin option, channel name (unstable, 25.05, ...), flake input, "
-    "or `/nix/store/` path. Use even when you think you know the answer — your training "
-    "data lags nixpkgs by months.\n\n"
+    "`/nix/store/` path, or the Den framework. Use even when you think you know the "
+    "answer — your training data lags nixpkgs by months.\n\n"
     "Two tools are exposed:\n"
     "- `nix` — unified search/info/stats/browse/channels/flake-inputs/cache/store across "
     "NixOS, Home Manager, nix-darwin, Nixvim, flakes, FlakeHub, NixHub, the NixOS wiki, "
-    "nix.dev, and Noogle. For package version *history* pair with `nix_versions`.\n"
+    "nix.dev, Noogle, and Den. For package version *history* pair with `nix_versions`.\n"
     "- `nix_versions` — commit-accurate history from NixHub (which nixpkgs commit "
     "shipped version X, what attribute path, which platforms).\n\n"
     "Common intents → calls (copy the JSON shape exactly):\n"
@@ -167,6 +177,7 @@ _SERVER_INSTRUCTIONS = (
     '  "home-manager option for X"          → nix {"action":"search","source":"home-manager","query":"X"}\n'
     '  "does X have a binary cache?"        → nix {"action":"cache","query":"X"}\n'
     '  "read /nix/store/<path>"             → nix {"action":"store","type":"read","query":"/nix/store/<path>"}\n'
+    '  "search Den docs for X"              → nix {"action":"search","source":"den","query":"X"}\n'
     '  "which commit shipped X version Y?"  → nix_versions {"package":"X","version":"Y"}\n'
 )
 
@@ -212,7 +223,7 @@ async def nix(
     source: Annotated[
         str,
         "Data source for search/info/stats/browse/cache. One of: nixos (default), "
-        "home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. "
+        "home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub, den. "
         "For action=flake-inputs, this may instead be a path to a flake directory; "
         "omit/default to use the current project. Ignored by action=store.",
     ] = "nixos",
@@ -253,6 +264,8 @@ async def nix(
       "search the NixOS wiki for X"       → {"action": "search", "query": "X", "source": "wiki"}
       "search nix.dev docs"               → {"action": "search", "query": "X", "source": "nix-dev"}
       "read a nix.dev page"               → {"action": "info", "query": "tutorials/nix-language", "source": "nix-dev"}
+      "search Den framework docs for X"   → {"action": "search", "query": "X", "source": "den"}
+      "read a Den doc page"               → {"action": "info", "query": "guides/from-zero-to-den", "source": "den"}
       "list inputs of current flake"      → {"action": "flake-inputs"}
       "ls inside flake input X"           → {"action": "flake-inputs", "type": "ls", "query": "X"}
       "read /nix/store/... file"          → {"action": "store", "type": "read", "query": "/nix/store/..."}
@@ -316,10 +329,12 @@ async def nix(
             return await asyncio.to_thread(_search_noogle, query, limit)
         elif source == "nixhub":
             return await _search_nixhub(query, limit)
+        elif source == "den":
+            return await asyncio.to_thread(_search_den, query, limit)
         else:
             return error(
                 f"Unknown source: {source!r}. Must be one of: "
-                "nixos, home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub, den."
             )
 
     elif action == "info":
@@ -354,10 +369,12 @@ async def nix(
             return await asyncio.to_thread(_info_noogle, query)
         elif source == "nixhub":
             return await _info_nixhub(query)
+        elif source == "den":
+            return await asyncio.to_thread(_info_den, query)
         else:
             return error(
                 f"Unknown source: {source!r}. For action=info, must be one of: "
-                "nixos, home-manager, darwin, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
+                "nixos, home-manager, darwin, flakehub, nixvim, wiki, nix-dev, noogle, nixhub, den."
             )
 
     elif action == "stats":
@@ -375,12 +392,14 @@ async def nix(
             return await asyncio.to_thread(_stats_nixvim)
         elif source == "noogle":
             return await asyncio.to_thread(_stats_noogle)
+        elif source == "den":
+            return await asyncio.to_thread(_stats_den)
         elif source in ["wiki", "nix-dev", "nixhub"]:
             return error(f"Stats not available for source={source}.")
         else:
             return error(
                 f"Unknown source: {source!r}. For action=stats, must be one of: "
-                "nixos, home-manager, darwin, flakes, flakehub, nixvim, noogle."
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, noogle, den."
             )
 
     elif action == "browse":
@@ -391,15 +410,17 @@ async def nix(
                 "To get a specific option's details, use: "
                 '{"action": "info", "query": "services.nginx.enable", "type": "option"}.'
             )
-        if source not in ["home-manager", "darwin", "nixvim", "noogle"]:
+        if source not in ["home-manager", "darwin", "nixvim", "noogle", "den"]:
             return error(
-                "action=browse only supports source in: home-manager, darwin, nixvim, noogle. "
+                "action=browse only supports source in: home-manager, darwin, nixvim, noogle, den. "
                 'Example: {"action": "browse", "query": "programs", "source": "home-manager"}'
             )
         if source == "nixvim":
             return await asyncio.to_thread(_browse_nixvim_options, query)
         if source == "noogle":
             return await asyncio.to_thread(_browse_noogle_options, query)
+        if source == "den":
+            return await asyncio.to_thread(_browse_den, query)
         return await asyncio.to_thread(_browse_options, source, query)
 
     elif action == "channels":
@@ -644,6 +665,8 @@ __all__ = [
     "NOOGLE_API",
     "NIXHUB_API",
     "CACHE_NIXOS_ORG",
+    "DEN_BASE_URL",
+    "DEN_OVERVIEW_URL",
     "MAX_FILE_SIZE",
     "DEFAULT_LINE_LIMIT",
     "MAX_LINE_LIMIT",
@@ -653,10 +676,12 @@ __all__ = [
     "NixvimCache",
     "NixDevCache",
     "NoogleCache",
+    "DenCache",
     "channel_cache",
     "nixvim_cache",
     "nixdev_cache",
     "noogle_cache",
+    "den_cache",
     # Utility functions
     "strip_html",
     "error",
@@ -697,6 +722,11 @@ __all__ = [
     # Wiki functions
     "_search_wiki",
     "_info_wiki",
+    # Den functions
+    "_search_den",
+    "_info_den",
+    "_stats_den",
+    "_browse_den",
     # nix.dev functions
     "_search_nixdev",
     "_info_nixdev",

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -211,7 +211,8 @@ async def nix(
         str,
         "One of: search, info, stats, browse, channels, flake-inputs, cache, store. "
         "Use 'search' for keyword lookup, 'info' for details about a specific name, "
-        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only). "
+        "'browse' to list entries under a prefix (home-manager/darwin/nixvim/noogle option trees, "
+        "or den doc pages). "
         "'store' reads files or lists directories at an explicit /nix/store/ path.",
     ],
     query: Annotated[
@@ -239,7 +240,7 @@ async def nix(
     version: Annotated[str, "Only used by action=cache. Package version (default: latest)."] = "latest",
     system: Annotated[str, "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all."] = "",
 ) -> str:
-    """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
+    """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub, Den.
 
     Use this tool for anything touching nixpkgs, Nix channels, flakes, NixOS / home-manager /
     darwin options, the binary cache, or /nix/store paths — even when you think you know the
@@ -276,8 +277,8 @@ async def nix(
 
     Notes:
       - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
-        for source=nixos — browse is for walking a pre-indexed option tree and only works with
-        home-manager, darwin, nixvim, or noogle.
+        for source=nixos — browse walks a pre-indexed hierarchy by prefix: option trees for
+        home-manager, darwin, nixvim, and noogle, or doc-page paths for den.
       - For source=nix-dev, action=info returns the page markdown. The query may be a bare
         docname like "tutorials/nix-language", the URL printed by nix-dev search
         ("https://nix.dev/tutorials/nix-language"), or a rendered ".html" URL.

--- a/mcp_nixos/sources/__init__.py
+++ b/mcp_nixos/sources/__init__.py
@@ -21,6 +21,14 @@ from .darwin import (
     _stats_darwin,
 )
 
+# Den framework documentation
+from .den import (
+    _browse_den,
+    _info_den,
+    _search_den,
+    _stats_den,
+)
+
 # Flake inputs (local nix store)
 from .flake_inputs import (
     _check_nix_available,
@@ -140,6 +148,11 @@ __all__ = [
     # Wiki
     "_search_wiki",
     "_info_wiki",
+    # Den
+    "_search_den",
+    "_info_den",
+    "_stats_den",
+    "_browse_den",
     # nix.dev
     "_search_nixdev",
     "_info_nixdev",

--- a/mcp_nixos/sources/den.py
+++ b/mcp_nixos/sources/den.py
@@ -1,0 +1,220 @@
+"""Den framework documentation source (https://den.denful.dev).
+
+Search, info, stats, and browse the Starlight-rendered Astro site that
+publishes the Den framework docs. Discovery and per-page parsing live in
+`DenCache`; this module is a thin formatter on top of it.
+"""
+
+from typing import Any
+
+from ..caches import den_cache
+from ..config import DEN_BASE_URL, APIError
+from ..utils import error
+
+# Cap the body we return from `_info_den` at ~200KB so a large page
+# doesn't blow the LLM context. The full Den docs corpus is small
+# (≈50 pages × a few KB each); 200KB is plenty for legitimate docs.
+_DEN_MAX_BODY_CHARS = 200_000
+
+# Browse output cap — matches `home-manager` / `darwin` browse behaviour.
+_DEN_BROWSE_LIMIT = 100
+
+
+def _score_page(page: dict[str, Any], query_lower: str) -> int:
+    """Score a Den page against a lowercased query.
+
+    Scoring is intentionally simple and matches the nix-dev / noogle style:
+    title hits are weighted higher than body hits, prefix matches on
+    titles are weighted higher still. Multi-term queries are split on
+    whitespace and each term contributes independently.
+    """
+    title = page.get("title", "").lower()
+    body = page.get("body", "").lower()
+
+    if not title and not body:
+        return 0
+
+    terms = [t for t in query_lower.split() if t]
+    if not terms:
+        return 0
+
+    score = 0
+    for term in terms:
+        score += title.count(term) * 5
+        score += body.count(term)
+        if title.startswith(term):
+            score += 3
+    return score
+
+
+def _search_den(query: str, limit: int) -> str:
+    """Search Den docs by case-insensitive substring on title + body."""
+    try:
+        pages = den_cache.get_pages()
+    except APIError:
+        raise
+    except Exception as e:
+        return error(str(e))
+
+    query_lower = query.lower().strip()
+    if not query_lower:
+        return error("Query required for den search")
+
+    scored: list[tuple[int, dict[str, Any]]] = []
+    for page in pages:
+        s = _score_page(page, query_lower)
+        if s > 0:
+            scored.append((s, page))
+
+    if not scored:
+        return f"No Den docs found matching '{query}'"
+
+    scored.sort(key=lambda x: (-x[0], x[1].get("path", "")))
+    top = scored[:limit]
+
+    results = [f"Found {len(top)} Den docs matching '{query}':\n"]
+    for _score, page in top:
+        path = page.get("path", "")
+        title = page.get("title", "")
+        results.append(f"* {title}")
+        results.append(f"  {DEN_BASE_URL}{path}")
+        results.append("")
+    return "\n".join(results).strip()
+
+
+def _info_den(query: str) -> str:
+    """Return a single Den page as plain text (title + body + url)."""
+    if not query or not query.strip():
+        return error("Query required for den info (path, slug, or URL)")
+
+    try:
+        page = den_cache.get_by_path(query)
+    except APIError:
+        raise
+    except Exception as e:
+        return error(str(e))
+
+    if page is None:
+        # No exact path match — try a basename fallback so the caller can
+        # pass a slug like "aspects" instead of "/explanation/aspects/".
+        slug = query.strip().strip("/").rsplit("/", 1)[-1]
+        try:
+            pages = den_cache.get_pages()
+        except APIError:
+            raise
+        except Exception as e:
+            return error(str(e))
+        matches = [p for p in pages if p.get("path", "").strip("/").rsplit("/", 1)[-1] == slug]
+        if matches:
+            page = matches[0]
+
+    if page is None:
+        return error(f"Den page not found: {query}", "NOT_FOUND")
+
+    title = page.get("title", "")
+    path = page.get("path", "")
+    url = page.get("url", f"{DEN_BASE_URL}{path}")
+    body = page.get("body", "").strip()
+
+    truncated = len(body) > _DEN_MAX_BODY_CHARS
+    if truncated:
+        body = body[:_DEN_MAX_BODY_CHARS]
+
+    lines = [
+        f"Title: {title}",
+        f"Source: {url}",
+        f"Path: {path}",
+        "",
+        body,
+    ]
+    if truncated:
+        lines.append("")
+        lines.append("[truncated]")
+    return "\n".join(lines)
+
+
+def _stats_den() -> str:
+    """Total Den pages + per-section page count."""
+    try:
+        pages = den_cache.get_pages()
+    except APIError:
+        raise
+    except Exception as e:
+        return error(str(e))
+
+    if not pages:
+        return error("Failed to fetch Den documentation statistics")
+
+    section_counts: dict[str, int] = {}
+    for page in pages:
+        path = page.get("path", "")
+        # First non-empty path segment after the leading slash is the
+        # section name (e.g., "/explanation/aspects/" -> "explanation").
+        parts = [p for p in path.strip("/").split("/") if p]
+        section = parts[0] if parts else "(root)"
+        section_counts[section] = section_counts.get(section, 0) + 1
+
+    sorted_sections = sorted(section_counts.items(), key=lambda x: (-x[1], x[0]))
+    lines = [
+        "Den Documentation Statistics:",
+        f"* Total pages: {len(pages):,}",
+        f"* Sections: {len(section_counts)}",
+        "* Pages per section:",
+    ]
+    for section, count in sorted_sections:
+        lines.append(f"  - {section}: {count}")
+    return "\n".join(lines)
+
+
+def _browse_den(prefix: str) -> str:
+    """Browse Den pages by path prefix; with no prefix, list top-level sections."""
+    try:
+        pages = den_cache.get_pages()
+    except APIError:
+        raise
+    except Exception as e:
+        return error(str(e))
+
+    if not prefix:
+        # Top-level section summary (mirrors `_browse_options` for hm/darwin).
+        section_counts: dict[str, int] = {}
+        for page in pages:
+            path = page.get("path", "")
+            parts = [p for p in path.strip("/").split("/") if p]
+            section = parts[0] if parts else "(root)"
+            section_counts[section] = section_counts.get(section, 0) + 1
+        if not section_counts:
+            return "No Den pages indexed"
+
+        sorted_sections = sorted(section_counts.items(), key=lambda x: (-x[1], x[0]))
+        results = [f"Den doc sections ({len(section_counts)} total):\n"]
+        for section, count in sorted_sections:
+            results.append(f"* {section} ({count} pages)")
+        return "\n".join(results)
+
+    # Normalize the prefix to a `/section/.../` shape.
+    norm = prefix.strip().strip("/")
+    if norm:
+        norm = "/" + norm
+    if not norm.endswith("/"):
+        norm = norm + "/"
+
+    matches = [p for p in pages if p.get("path", "").startswith(norm)]
+    if not matches:
+        return f"No Den pages found with prefix '{prefix}'"
+
+    matches.sort(key=lambda p: p.get("path", ""))
+    matches = matches[:_DEN_BROWSE_LIMIT]
+
+    results = [f"Den pages with prefix '{prefix}' ({len(matches)} found):\n"]
+    for page in matches:
+        path = page.get("path", "")
+        title = page.get("title", "")
+        results.append(f"* {path} — {title}")
+    if len(matches) == _DEN_BROWSE_LIMIT:
+        # We truncated; check if there are more.
+        total = sum(1 for p in pages if p.get("path", "").startswith(norm))
+        if total > _DEN_BROWSE_LIMIT:
+            results.append("")
+            results.append(f"... and {total - _DEN_BROWSE_LIMIT} more pages")
+    return "\n".join(results)

--- a/mcp_nixos/sources/den.py
+++ b/mcp_nixos/sources/den.py
@@ -51,8 +51,8 @@ def _search_den(query: str, limit: int) -> str:
     """Search Den docs by case-insensitive substring on title + body."""
     try:
         pages = den_cache.get_pages()
-    except APIError:
-        raise
+    except APIError as exc:
+        return error(str(exc), "API_ERROR")
     except Exception as e:
         return error(str(e))
 
@@ -89,8 +89,8 @@ def _info_den(query: str) -> str:
 
     try:
         page = den_cache.get_by_path(query)
-    except APIError:
-        raise
+    except APIError as exc:
+        return error(str(exc), "API_ERROR")
     except Exception as e:
         return error(str(e))
 
@@ -100,8 +100,8 @@ def _info_den(query: str) -> str:
         slug = query.strip().strip("/").rsplit("/", 1)[-1]
         try:
             pages = den_cache.get_pages()
-        except APIError:
-            raise
+        except APIError as exc:
+            return error(str(exc), "API_ERROR")
         except Exception as e:
             return error(str(e))
         matches = [p for p in pages if p.get("path", "").strip("/").rsplit("/", 1)[-1] == slug]
@@ -137,8 +137,8 @@ def _stats_den() -> str:
     """Total Den pages + per-section page count."""
     try:
         pages = den_cache.get_pages()
-    except APIError:
-        raise
+    except APIError as exc:
+        return error(str(exc), "API_ERROR")
     except Exception as e:
         return error(str(e))
 
@@ -170,8 +170,8 @@ def _browse_den(prefix: str) -> str:
     """Browse Den pages by path prefix; with no prefix, list top-level sections."""
     try:
         pages = den_cache.get_pages()
-    except APIError:
-        raise
+    except APIError as exc:
+        return error(str(exc), "API_ERROR")
     except Exception as e:
         return error(str(e))
 

--- a/mcp_nixos/sources/den.py
+++ b/mcp_nixos/sources/den.py
@@ -49,17 +49,16 @@ def _score_page(page: dict[str, Any], query_lower: str) -> int:
 
 def _search_den(query: str, limit: int) -> str:
     """Search Den docs by case-insensitive substring on title + body."""
+    query_lower = query.lower().strip()
+    if not query_lower:
+        return error("Query required for den search")
+
     try:
         pages = den_cache.get_pages()
     except APIError as exc:
         return error(str(exc), "API_ERROR")
     except Exception as e:
         return error(str(e))
-
-    query_lower = query.lower().strip()
-    if not query_lower:
-        return error("Query required for den search")
-
     scored: list[tuple[int, dict[str, Any]]] = []
     for page in pages:
         s = _score_page(page, query_lower)

--- a/mcp_nixos/sources/den.py
+++ b/mcp_nixos/sources/den.py
@@ -174,7 +174,12 @@ def _browse_den(prefix: str) -> str:
     except Exception as e:
         return error(str(e))
 
-    if not prefix:
+    # A blank or slash-only prefix carries no path component; treat it like an
+    # omitted prefix and show the section summary. This collapses whitespace-
+    # only input ("   ") and a bare "/" to the no-prefix case, rather than
+    # normalizing to "/" and matching every page.
+    core = prefix.strip().strip("/")
+    if not core:
         # Top-level section summary (mirrors `_browse_options` for hm/darwin).
         section_counts: dict[str, int] = {}
         for page in pages:
@@ -192,28 +197,23 @@ def _browse_den(prefix: str) -> str:
         return "\n".join(results)
 
     # Normalize the prefix to a `/section/.../` shape.
-    norm = prefix.strip().strip("/")
-    if norm:
-        norm = "/" + norm
-    if not norm.endswith("/"):
-        norm = norm + "/"
+    norm = f"/{core}/"
 
     matches = [p for p in pages if p.get("path", "").startswith(norm)]
     if not matches:
-        return f"No Den pages found with prefix '{prefix}'"
+        return f"No Den pages found with prefix '{core}'"
 
     matches.sort(key=lambda p: p.get("path", ""))
-    matches = matches[:_DEN_BROWSE_LIMIT]
 
-    results = [f"Den pages with prefix '{prefix}' ({len(matches)} found):\n"]
-    for page in matches:
+    # Header reports the *total* match count; the listing is capped at
+    # _DEN_BROWSE_LIMIT with a trailing "... and N more" note (mirrors the
+    # nixvim / noogle browse helpers, which count before truncating).
+    results = [f"Den pages with prefix '{core}' ({len(matches)} found):\n"]
+    for page in matches[:_DEN_BROWSE_LIMIT]:
         path = page.get("path", "")
         title = page.get("title", "")
         results.append(f"* {path} — {title}")
-    if len(matches) == _DEN_BROWSE_LIMIT:
-        # We truncated; check if there are more.
-        total = sum(1 for p in pages if p.get("path", "").startswith(norm))
-        if total > _DEN_BROWSE_LIMIT:
-            results.append("")
-            results.append(f"... and {total - _DEN_BROWSE_LIMIT} more pages")
+    if len(matches) > _DEN_BROWSE_LIMIT:
+        results.append("")
+        results.append(f"... and {len(matches) - _DEN_BROWSE_LIMIT} more pages")
     return "\n".join(results)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -395,6 +395,41 @@ class TestNixDevIntegration:
         assert_plain_text(result)
 
 
+class TestDenIntegration:
+    """Integration tests for Den framework docs (issue #156)."""
+
+    @pytest.mark.asyncio
+    async def test_search_den_aspects(self):
+        """A search for "aspects" surfaces the Aspects & Functors explanation."""
+        from mcp_nixos.server import den_cache
+
+        den_cache.pages = None  # Reset cache for fresh fetch
+
+        result = await nix_fn(action="search", query="aspects", source="den", limit=5)
+        assert isinstance(result, str)
+        assert "Found" in result, result
+        assert "/explanation/aspects/" in result or "/reference/aspects/" in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_info_den_from_zero_to_den(self):
+        """info returns a real Den page with title + body for a stable guide."""
+        from mcp_nixos.server import den_cache
+
+        den_cache.pages = None
+
+        result = await nix_fn(
+            action="info",
+            query="guides/from-zero-to-den",
+            source="den",
+        )
+        assert isinstance(result, str)
+        assert not result.startswith("Error"), result
+        assert "Title:" in result
+        assert "Source: https://den.denful.dev/guides/from-zero-to-den/" in result
+        assert_plain_text(result)
+
+
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 class TestFlakeInputsIntegration:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -395,15 +395,22 @@ class TestNixDevIntegration:
         assert_plain_text(result)
 
 
+@pytest.mark.integration
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 class TestDenIntegration:
     """Integration tests for Den framework docs (issue #156)."""
+
+    def _reset_den_cache(self):
+        """Reset both stores so `action=info` can't resolve from stale state."""
+        from mcp_nixos.server import den_cache
+
+        den_cache.pages = None
+        den_cache._by_path = None
 
     @pytest.mark.asyncio
     async def test_search_den_aspects(self):
         """A search for "aspects" surfaces the Aspects & Functors explanation."""
-        from mcp_nixos.server import den_cache
-
-        den_cache.pages = None  # Reset cache for fresh fetch
+        self._reset_den_cache()
 
         result = await nix_fn(action="search", query="aspects", source="den", limit=5)
         assert isinstance(result, str)
@@ -414,9 +421,7 @@ class TestDenIntegration:
     @pytest.mark.asyncio
     async def test_info_den_from_zero_to_den(self):
         """info returns a real Den page with title + body for a stable guide."""
-        from mcp_nixos.server import den_cache
-
-        den_cache.pages = None
+        self._reset_den_cache()
 
         result = await nix_fn(
             action="info",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1037,6 +1037,32 @@ class TestDenCache:
         # URL-encoded slashes / etc. are decoded.
         assert DenCache._normalize_path("/explanation/aspects%2Fother/") == "/explanation/aspects/other/"
 
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_prefers_main_with_data_pagefind_body(self, mock_get):
+        """When a page has both a plain <main> and a <main data-pagefind-body>,
+        the data-pagefind-body one wins. Defends against the `or True`
+        tautology regression flagged by Copilot and CodeRabbit on PR #176."""
+        from mcp_nixos.caches import DenCache
+
+        # The first <main> is decoration / navigation chrome; the second is
+        # the actual article body. Without the data-pagefind-body filter the
+        # wrong one would be picked.
+        html = (
+            "<html><body>"
+            "<main><h1>navigation chrome</h1></main>"
+            "<main data-pagefind-body>"
+            '<h1 id="_top">Aspects</h1>'
+            '<div class="sl-markdown-content"><p>real body</p></div>'
+            "</main></body></html>"
+        )
+        mock_get.return_value = self._http(html)
+
+        page = DenCache._fetch_page("/explanation/aspects/")
+        assert page is not None
+        assert page["title"] == "Aspects"
+        assert "real body" in page["body"]
+        assert "navigation chrome" not in page["body"]
+
 
 @pytest.mark.unit
 class TestDenFunctions:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1251,6 +1251,39 @@ class TestDenFunctions:
         assert "No Den pages found" in result
 
     @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_whitespace_prefix_lists_sections(self, mock_cache):
+        """A whitespace-only (or bare-slash) prefix behaves like no prefix:
+        it lists sections instead of normalizing to '/' and dumping every page.
+        Regression for Copilot's PR #176 finding."""
+        from mcp_nixos.server import _browse_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/explanation/aspects/", "A1", "x"),
+            self._page("/guides/from-zero-to-den/", "G1", "x"),
+        ]
+        for blank in ("   ", "/", "  /  "):
+            result = _browse_den(blank)
+            assert "Den doc sections" in result, (blank, result)
+            # Must NOT fall through to the "(N found)" all-pages listing.
+            assert "found)" not in result, (blank, result)
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_header_count_is_total_not_truncated(self, mock_cache):
+        """When matches exceed the browse cap, the header reports the *total*
+        count and a trailing note shows how many were elided (mirrors nixvim /
+        noogle). Regression for Copilot's PR #176 finding."""
+        from mcp_nixos.server import _browse_den
+        from mcp_nixos.sources.den import _DEN_BROWSE_LIMIT
+
+        total = _DEN_BROWSE_LIMIT + 5
+        mock_cache.get_pages.return_value = [
+            self._page(f"/guides/page-{i:03d}/", f"Page {i}", "x") for i in range(total)
+        ]
+        result = _browse_den("guides")
+        assert f"({total} found)" in result, result
+        assert f"... and {total - _DEN_BROWSE_LIMIT} more pages" in result, result
+
+    @patch("mcp_nixos.sources.den.den_cache")
     def test_search_handles_cache_error(self, mock_cache):
         """APIError from the cache is converted to a plain-text `Error (...)`
         response (mirrors nix-dev / noogle)."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -849,3 +849,387 @@ class TestNooglePlainTextOutput:
         assert "<error>" not in result
         assert "</error>" not in result
         assert not result.strip().startswith("{")
+
+
+@pytest.mark.unit
+class TestDenCache:
+    """Test DenCache (issue #156)."""
+
+    def _fresh_cache(self):
+        """Reset the module-level den_cache singleton."""
+        from mcp_nixos import caches
+
+        caches.den_cache = caches.DenCache()
+        return caches.den_cache
+
+    def _overview_html(self, links: list[str]) -> str:
+        """Build a /overview/ page containing the given internal doc links."""
+        anchors = "".join(f'<a href="{href}">{href}</a>' for href in links)
+        return f"<html><body><main>{anchors}</main></body></html>"
+
+    def _page_html(self, title: str, body_html: str):
+        """Build a Mock response carrying a Starlight-shaped page body."""
+        html = (
+            f"<html><body><main data-pagefind-body>"
+            f'<h1 id="_top">{title}</h1>'
+            f'<div class="sl-markdown-content">{body_html}</div>'
+            f"</main></body></html>"
+        )
+        return self._http(html)
+
+    def _http(self, html: str, status: int = 200):
+        """Build a Mock response carrying the given HTML body."""
+        resp = Mock(status_code=status, raise_for_status=Mock())
+        resp.content = html.encode("utf-8")
+        resp.ok = status < 400
+        return resp
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_discover_paths_filters_to_doc_prefixes(self, mock_get):
+        """Only paths under doc prefixes are kept; nav, community, etc. are dropped."""
+
+        mock_get.return_value = self._http(
+            self._overview_html(
+                [
+                    "/explanation/aspects/",  # kept
+                    "/guides/from-zero-to-den",  # kept (normalised to trailing /)
+                    "/reference/aspects/",  # kept
+                    "/tutorials/microvm",  # kept
+                    "/community",  # dropped
+                    "/contributing/",  # dropped
+                    "/releases#bleeding-edge-den",  # dropped (anchor)
+                    "https://github.com/denful/den",  # dropped (external)
+                    "/",  # dropped
+                ]
+            )
+        )
+
+        cache = self._fresh_cache()
+        paths = cache._discover_paths()
+        # Normalise: every path should have a trailing slash and a leading slash.
+        assert all(p.startswith("/") and p.endswith("/") for p in paths)
+        assert "/explanation/aspects/" in paths
+        assert "/guides/from-zero-to-den/" in paths
+        assert "/reference/aspects/" in paths
+        assert "/tutorials/microvm/" in paths
+        for dropped in ("/community", "/contributing", "/releases", "/"):
+            assert not any(p == dropped or p == dropped + "/" for p in paths)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_discover_paths_dedups(self, mock_get):
+        """The same link appearing twice in the overview is returned once."""
+
+        mock_get.return_value = self._http(
+            self._overview_html(
+                [
+                    "/guides/from-zero-to-den/",
+                    "/guides/from-zero-to-den",  # dup (normalised)
+                    "/guides/from-zero-to-den/#section",  # dup (anchor stripped)
+                ]
+            )
+        )
+
+        cache = self._fresh_cache()
+        paths = cache._discover_paths()
+        assert paths.count("/guides/from-zero-to-den/") == 1
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_discover_paths_overview_failure_raises(self, mock_get):
+        """A 5xx response from /overview/ raises APIError."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.return_value = self._http("", status=502)
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache._discover_paths()
+        assert "HTTP 502" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_discover_paths_request_error_raises(self, mock_get):
+        """A network error during overview fetch surfaces as APIError."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.side_effect = requests.RequestException("connection reset")
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache._discover_paths()
+        assert "Failed to fetch Den overview" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_pages_empty_overview_raises(self, mock_get):
+        """If the overview has no doc links, get_pages raises APIError."""
+        from mcp_nixos.caches import APIError
+
+        mock_get.return_value = self._http(self._overview_html(["/community", "/contributing"]))
+
+        cache = self._fresh_cache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_pages()
+        assert "No Den docs paths discovered" in str(exc_info.value)
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_pages_uses_thread_pool(self, mock_get):
+        """get_pages fans out per-page fetches via the thread pool."""
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/overview/"):
+                return self._http(
+                    self._overview_html(
+                        [
+                            "/guides/from-zero-to-den/",
+                            "/explanation/aspects/",
+                        ]
+                    )
+                )
+            if url.endswith("/guides/from-zero-to-den/"):
+                return self._page_html("From Zero to Den", "<p>Intro body.</p>")
+            if url.endswith("/explanation/aspects/"):
+                return self._page_html("Aspects & Functors", "<p>Aspects body.</p>")
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        pages = cache.get_pages()
+        assert len(pages) == 2
+        names = {p["title"] for p in pages}
+        assert names == {"From Zero to Den", "Aspects & Functors"}
+        # First call is the overview, the rest are the two page fetches.
+        assert mock_get.call_count == 3
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_get_pages_skips_404_page(self, mock_get):
+        """A page that 404s is silently skipped, not surfaced as an error."""
+
+        def fake_get(url, **_kwargs):
+            if url.endswith("/overview/"):
+                return self._http(
+                    self._overview_html(
+                        [
+                            "/guides/from-zero-to-den/",
+                            "/explanation/aspects/",
+                        ]
+                    )
+                )
+            if url.endswith("/guides/from-zero-to-den/"):
+                return self._http("", status=404)
+            if url.endswith("/explanation/aspects/"):
+                return self._page_html("Aspects", "<p>Body.</p>")
+            raise AssertionError(f"Unexpected URL in test: {url}")
+
+        mock_get.side_effect = fake_get
+
+        cache = self._fresh_cache()
+        pages = cache.get_pages()
+        assert len(pages) == 1
+        assert pages[0]["title"] == "Aspects"
+
+    def test_normalize_path(self):
+        """Path normalization handles bare slugs, full URLs, and edge cases."""
+        from mcp_nixos.caches import DenCache
+
+        assert DenCache._normalize_path("/guides/from-zero-to-den/") == "/guides/from-zero-to-den/"
+        assert DenCache._normalize_path("guides/from-zero-to-den") == "/guides/from-zero-to-den/"
+        assert DenCache._normalize_path("https://den.denful.dev/explanation/aspects/") == "/explanation/aspects/"
+        assert DenCache._normalize_path("/explanation/aspects/#anchor") == "/explanation/aspects/"
+        # URL-encoded slashes / etc. are decoded.
+        assert DenCache._normalize_path("/explanation/aspects%2Fother/") == "/explanation/aspects/other/"
+
+
+@pytest.mark.unit
+class TestDenFunctions:
+    """Test _search_den / _info_den / _stats_den / _browse_den (issue #156)."""
+
+    def _page(self, path, title, body):
+        return {
+            "path": path,
+            "url": f"https://den.denful.dev{path}",
+            "title": title,
+            "body": body,
+        }
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_basic(self, mock_cache):
+        """A title hit ranks above a body hit, and a prefix bonus pushes it higher."""
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/explanation/aspects/", "Aspects & Functors", "Body about aspects."),
+            self._page("/reference/lib/", "Library Reference", "Some mention of aspects here."),
+        ]
+
+        result = _search_den("aspects", 5)
+        # Title hit should come first.
+        assert result.index("Aspects & Functors") < result.index("Library Reference")
+        assert "Found 2 Den docs" in result
+        assert "https://den.denful.dev/explanation/aspects/" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_no_results(self, mock_cache):
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.return_value = [self._page("/explanation/aspects/", "Aspects", "x")]
+        result = _search_den("nonexistentterm", 5)
+        assert "No Den docs found" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_case_insensitive(self, mock_cache):
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/explanation/aspects/", "Aspects & Functors", "Body about aspects.")
+        ]
+        # Uppercase query still matches a lowercase title.
+        result = _search_den("ASPECTS", 5)
+        assert "Aspects & Functors" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_empty_query_reports_error(self, mock_cache):
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.return_value = []
+        result = _search_den("", 5)
+        assert "Error" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_multi_term_accumulates_score(self, mock_cache):
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/x/a/", "A", "alpha"),
+            self._page("/x/b/", "B", "alpha alpha beta"),
+        ]
+        result = _search_den("alpha beta", 5)
+        # The page that has both terms should rank first.
+        assert result.index("* B") < result.index("* A")
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_path_match(self, mock_cache):
+        from mcp_nixos.server import _info_den
+
+        mock_cache.get_pages.return_value = []
+        mock_cache.get_by_path.return_value = self._page("/explanation/aspects/", "Aspects & Functors", "Body content.")
+
+        result = _info_den("/explanation/aspects/")
+        assert "Title: Aspects & Functors" in result
+        assert "https://den.denful.dev/explanation/aspects/" in result
+        assert "Path: /explanation/aspects/" in result
+        assert "Body content." in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_url_match(self, mock_cache):
+        from mcp_nixos.server import _info_den
+
+        mock_cache.get_pages.return_value = []
+        mock_cache.get_by_path.return_value = self._page("/explanation/aspects/", "Aspects & Functors", "Body content.")
+        result = _info_den("https://den.denful.dev/explanation/aspects/")
+        assert "Title: Aspects & Functors" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_slug_fallback(self, mock_cache):
+        from mcp_nixos.server import _info_den
+
+        aspect_page = self._page("/explanation/aspects/", "Aspects & Functors", "Body content.")
+        # First call to get_by_path returns None (no match for "aspects" as a path)
+        # so the slug-fallback kicks in via get_pages().
+        mock_cache.get_by_path.return_value = None
+        mock_cache.get_pages.return_value = [aspect_page]
+
+        result = _info_den("aspects")
+        assert "Title: Aspects & Functors" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_not_found(self, mock_cache):
+        from mcp_nixos.server import _info_den
+
+        mock_cache.get_by_path.return_value = None
+        mock_cache.get_pages.return_value = [self._page("/explanation/aspects/", "Aspects", "Body content.")]
+        result = _info_den("nonexistent-slug")
+        assert "Error" in result
+        assert "NOT_FOUND" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_empty_query(self, mock_cache):
+        from mcp_nixos.server import _info_den
+
+        result = _info_den("")
+        assert "Error" in result
+        assert "Query required" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_truncates_long_body(self, mock_cache):
+        from mcp_nixos.server import _info_den
+        from mcp_nixos.sources.den import _DEN_MAX_BODY_CHARS
+
+        long_body = "x" * (_DEN_MAX_BODY_CHARS + 5000)
+        mock_cache.get_pages.return_value = []
+        mock_cache.get_by_path.return_value = self._page("/explanation/aspects/", "Aspects", long_body)
+        result = _info_den("/explanation/aspects/")
+        assert "[truncated]" in result
+        # The full body should not appear in the result.
+        assert long_body not in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_stats_basic(self, mock_cache):
+        from mcp_nixos.server import _stats_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/explanation/aspects/", "A1", "x"),
+            self._page("/explanation/policies/", "A2", "x"),
+            self._page("/guides/from-zero-to-den/", "G1", "x"),
+            self._page("/reference/lib/", "R1", "x"),
+        ]
+        result = _stats_den()
+        assert "Total pages: 4" in result
+        assert "explanation: 2" in result
+        assert "guides: 1" in result
+        assert "reference: 1" in result
+        assert "Sections: 3" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_no_prefix_lists_sections(self, mock_cache):
+        from mcp_nixos.server import _browse_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/explanation/aspects/", "A1", "x"),
+            self._page("/guides/from-zero-to-den/", "G1", "x"),
+        ]
+        result = _browse_den("")
+        assert "Den doc sections" in result
+        assert "explanation (1 pages)" in result
+        assert "guides (1 pages)" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_with_prefix(self, mock_cache):
+        from mcp_nixos.server import _browse_den
+
+        mock_cache.get_pages.return_value = [
+            self._page("/guides/from-zero-to-den/", "From Zero to Den", "x"),
+            self._page("/guides/from-flake-to-den/", "From Flake to Den", "x"),
+            self._page("/explanation/aspects/", "Aspects", "x"),
+        ]
+        result = _browse_den("guides")
+        assert "Den pages with prefix 'guides' (2 found)" in result
+        assert "/guides/from-zero-to-den/ — From Zero to Den" in result
+        assert "/guides/from-flake-to-den/ — From Flake to Den" in result
+        # Explanation page must not appear under /guides/.
+        assert "Aspects" not in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_no_matches(self, mock_cache):
+        from mcp_nixos.server import _browse_den
+
+        mock_cache.get_pages.return_value = [self._page("/explanation/aspects/", "Aspects", "x")]
+        result = _browse_den("nonexistent-section")
+        assert "No Den pages found" in result
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_search_handles_cache_error(self, mock_cache):
+        from mcp_nixos.caches import APIError
+        from mcp_nixos.server import _search_den
+
+        mock_cache.get_pages.side_effect = APIError("boom")
+        with pytest.raises(APIError):
+            _search_den("anything", 5)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1358,13 +1358,6 @@ class TestDenFunctions:
                 r.ok = status < 400
                 return r
 
-            def fake_get(url, **_kwargs):
-                if url.endswith("/overview/"):
-                    return _resp(listing_html)
-                if url.endswith("/explanation/aspects/"):
-                    return _resp(page_html)
-                return _resp("", status=404)
-
             # Provide enough responses for any number of walks.
             mock_get.side_effect = [
                 _resp(listing_html),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1227,9 +1227,129 @@ class TestDenFunctions:
 
     @patch("mcp_nixos.sources.den.den_cache")
     def test_search_handles_cache_error(self, mock_cache):
+        """APIError from the cache is converted to a plain-text `Error (...)`
+        response (mirrors nix-dev / noogle)."""
         from mcp_nixos.caches import APIError
         from mcp_nixos.server import _search_den
 
         mock_cache.get_pages.side_effect = APIError("boom")
-        with pytest.raises(APIError):
-            _search_den("anything", 5)
+        result = _search_den("anything", 5)
+        assert result == "Error (API_ERROR): boom"
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_info_handles_cache_error(self, mock_cache):
+        from mcp_nixos.caches import APIError
+        from mcp_nixos.server import _info_den
+
+        mock_cache.get_by_path.side_effect = APIError("boom")
+        result = _info_den("/anything/")
+        assert result == "Error (API_ERROR): boom"
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_stats_handles_cache_error(self, mock_cache):
+        from mcp_nixos.caches import APIError
+        from mcp_nixos.server import _stats_den
+
+        mock_cache.get_pages.side_effect = APIError("boom")
+        result = _stats_den()
+        assert result == "Error (API_ERROR): boom"
+
+    @patch("mcp_nixos.sources.den.den_cache")
+    def test_browse_handles_cache_error(self, mock_cache):
+        from mcp_nixos.caches import APIError
+        from mcp_nixos.server import _browse_den
+
+        mock_cache.get_pages.side_effect = APIError("boom")
+        result = _browse_den("anything")
+        assert result == "Error (API_ERROR): boom"
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_5xx_propagates(self, mock_get):
+        """A 5xx from a Den page lets the exception propagate up to the
+        ThreadPoolExecutor future in get_pages(), where it's wrapped as
+        APIError('Failed to fetch Den page ...')."""
+        from mcp_nixos import caches
+        from mcp_nixos.caches import APIError
+
+        listing_html = '<html><body><a href="/explanation/aspects/">a</a></body></html>'
+
+        resp_5xx = Mock(status_code=502)
+        resp_5xx.raise_for_status = Mock(side_effect=requests.HTTPError("502 Bad Gateway"))
+
+        overview = Mock(status_code=200, raise_for_status=Mock())
+        overview.content = listing_html.encode("utf-8")
+        overview.ok = True
+
+        mock_get.side_effect = [overview, resp_5xx]
+
+        original = caches.den_cache
+        cache = caches.DenCache()
+        caches.den_cache = cache
+        try:
+            with pytest.raises(APIError) as exc_info:
+                cache.get_pages()
+            assert "Failed to fetch Den page" in str(exc_info.value)
+        finally:
+            caches.den_cache = original
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fetch_page_404_returns_none(self, mock_get):
+        """A 404 means the overview linked to a page that no longer exists;
+        skip silently so a stale link doesn't take the whole cache down."""
+        from mcp_nixos.caches import DenCache
+
+        resp = Mock(status_code=404)
+        mock_get.return_value = resp
+
+        assert DenCache._fetch_page("/nonexistent/") is None
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_concurrent_first_call_only_fetches_once(self, mock_get):
+        """Double-checked locking: N concurrent first calls run the walk
+        exactly once, not N times."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        from mcp_nixos import caches
+
+        # The _fresh_cache helper lives on TestDenCache; build a fresh
+        # singleton here directly. Restore in finally so we don't leak
+        # state into other tests.
+        original = caches.den_cache
+        cache = caches.DenCache()
+        caches.den_cache = cache
+        try:
+            listing_html = '<html><body><a href="/explanation/aspects/">a</a></body></html>'
+            page_html = (
+                "<html><body><main data-pagefind-body>"
+                '<h1 id="_top">Aspects</h1>'
+                '<div class="sl-markdown-content"><p>Body.</p></div>'
+                "</main></body></html>"
+            )
+
+            def _resp(html: str, status: int = 200):
+                r = Mock(status_code=status, raise_for_status=Mock())
+                r.content = html.encode("utf-8")
+                r.ok = status < 400
+                return r
+
+            def fake_get(url, **_kwargs):
+                if url.endswith("/overview/"):
+                    return _resp(listing_html)
+                if url.endswith("/explanation/aspects/"):
+                    return _resp(page_html)
+                return _resp("", status=404)
+
+            # Provide enough responses for any number of walks.
+            mock_get.side_effect = [
+                _resp(listing_html),
+                _resp(page_html),
+                _resp("", status=404),
+            ] * 50
+
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                list(pool.map(lambda _: cache.get_pages(), range(20)))
+
+            # Exactly one walk: 1 overview + 1 page = 2 calls.
+            assert mock_get.call_count == 2
+        finally:
+            caches.den_cache = original

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -856,11 +856,10 @@ class TestDenCache:
     """Test DenCache (issue #156)."""
 
     def _fresh_cache(self):
-        """Reset the module-level den_cache singleton."""
-        from mcp_nixos import caches
+        """Return an isolated DenCache instance (no global state touched)."""
+        from mcp_nixos.caches import DenCache
 
-        caches.den_cache = caches.DenCache()
-        return caches.den_cache
+        return DenCache()
 
     def _overview_html(self, links: list[str]) -> str:
         """Build a /overview/ page containing the given internal doc links."""
@@ -1294,8 +1293,7 @@ class TestDenFunctions:
         """A 5xx from a Den page lets the exception propagate up to the
         ThreadPoolExecutor future in get_pages(), where it's wrapped as
         APIError('Failed to fetch Den page ...')."""
-        from mcp_nixos import caches
-        from mcp_nixos.caches import APIError
+        from mcp_nixos.caches import APIError, DenCache
 
         listing_html = '<html><body><a href="/explanation/aspects/">a</a></body></html>'
 
@@ -1308,15 +1306,11 @@ class TestDenFunctions:
 
         mock_get.side_effect = [overview, resp_5xx]
 
-        original = caches.den_cache
-        cache = caches.DenCache()
-        caches.den_cache = cache
-        try:
-            with pytest.raises(APIError) as exc_info:
-                cache.get_pages()
-            assert "Failed to fetch Den page" in str(exc_info.value)
-        finally:
-            caches.den_cache = original
+        # Isolated instance; nothing reads the module-level singleton here.
+        cache = DenCache()
+        with pytest.raises(APIError) as exc_info:
+            cache.get_pages()
+        assert "Failed to fetch Den page" in str(exc_info.value)
 
     @patch("mcp_nixos.caches.requests.get")
     def test_fetch_page_404_returns_none(self, mock_get):
@@ -1335,40 +1329,35 @@ class TestDenFunctions:
         exactly once, not N times."""
         from concurrent.futures import ThreadPoolExecutor
 
-        from mcp_nixos import caches
+        from mcp_nixos.caches import DenCache
 
-        # The _fresh_cache helper lives on TestDenCache; build a fresh
-        # singleton here directly. Restore in finally so we don't leak
-        # state into other tests.
-        original = caches.den_cache
-        cache = caches.DenCache()
-        caches.den_cache = cache
-        try:
-            listing_html = '<html><body><a href="/explanation/aspects/">a</a></body></html>'
-            page_html = (
-                "<html><body><main data-pagefind-body>"
-                '<h1 id="_top">Aspects</h1>'
-                '<div class="sl-markdown-content"><p>Body.</p></div>'
-                "</main></body></html>"
-            )
+        # Isolated instance per test; nothing here reads the module-level
+        # singleton, so there's no global state to swap or restore.
+        cache = DenCache()
 
-            def _resp(html: str, status: int = 200):
-                r = Mock(status_code=status, raise_for_status=Mock())
-                r.content = html.encode("utf-8")
-                r.ok = status < 400
-                return r
+        listing_html = '<html><body><a href="/explanation/aspects/">a</a></body></html>'
+        page_html = (
+            "<html><body><main data-pagefind-body>"
+            '<h1 id="_top">Aspects</h1>'
+            '<div class="sl-markdown-content"><p>Body.</p></div>'
+            "</main></body></html>"
+        )
 
-            # Provide enough responses for any number of walks.
-            mock_get.side_effect = [
-                _resp(listing_html),
-                _resp(page_html),
-                _resp("", status=404),
-            ] * 50
+        def _resp(html: str, status: int = 200):
+            r = Mock(status_code=status, raise_for_status=Mock())
+            r.content = html.encode("utf-8")
+            r.ok = status < 400
+            return r
 
-            with ThreadPoolExecutor(max_workers=8) as pool:
-                list(pool.map(lambda _: cache.get_pages(), range(20)))
+        # Provide enough responses for any number of walks.
+        mock_get.side_effect = [
+            _resp(listing_html),
+            _resp(page_html),
+            _resp("", status=404),
+        ] * 50
 
-            # Exactly one walk: 1 overview + 1 page = 2 calls.
-            assert mock_get.call_count == 2
-        finally:
-            caches.den_cache = original
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: cache.get_pages(), range(20)))
+
+        # Exactly one walk: 1 overview + 1 page = 2 calls.
+        assert mock_get.call_count == 2


### PR DESCRIPTION
Closes #156.

## What this adds

The Den framework docs (https://den.denful.dev) are now queryable via
the `nix` tool as `source=den`. The new source mirrors the existing
`nix-dev` source:

- `action=search source=den query=<term>` — case-insensitive substring
  search across all page titles and bodies, scored (title hits weight
  5×, with a +3 prefix bonus).
- `action=info source=den query=<path>` — return a single page as
  plain text. The query may be a bare path (`/guides/from-zero-to-den/`),
  a path without leading/trailing slashes (`guides/from-zero-to-den`),
  a full URL, or just the slug (`from-zero-to-den`, basename fallback).
- `action=stats source=den` — total page count + per-section breakdown
  (explanation / guides / reference / tutorials / motivation /
  maintainers / overview).
- `action=browse source=den query=<prefix>` — list pages under a path
  prefix. No prefix → top-level section summary.

## How it works

The Den site is Starlight-rendered Astro with no `sitemap.xml` and
no Pagefind JSON metadata (the Pagefind index is a bincode binary
that needs WASM to read), so the loader does its own walk:

1. **Discovery** — fetch `/overview/` once. Its sidebar links to
   every doc page; we extract the `/explanation/|/guides/|/reference/
   |/tutorials/|/motivation/|/maintainers/|/overview/` paths.
2. **Parallel fetch** — each page is fetched in a 10-worker
   `ThreadPoolExecutor` and parsed for the `<h1 id="_top">` title
   plus the `<main data-pagefind-body>` body (stripped of HTML to
   plain text). A 404 on a single page is skipped silently.
3. **Index** — flat in-memory `pages: list[dict]` + `by_path: dict`
   for exact lookups.

Total payload is small (≈55 pages × a few KB each); the cold-start
walk takes ~3 s. Subsequent calls are O(n) over the cached list.

## Files changed

| File | Change |
|---|---|
| `mcp_nixos/config.py` | +`DEN_BASE_URL`, +`DEN_OVERVIEW_URL`, +`"den"` in `KNOWN_SOURCES` |
| `mcp_nixos/caches.py` | +`DenCache` class + module-level `den_cache` instance |
| `mcp_nixos/sources/den.py` | **new** (~200 lines): `_search_den`, `_info_den`, `_stats_den`, `_browse_den`, with `_DEN_MAX_BODY_CHARS` cap on info output |
| `mcp_nixos/sources/__init__.py` | re-exports for the new symbols |
| `mcp_nixos/server.py` | +imports, +2 dispatch branches (search/info), +1 in stats, +`"den"` in browse allow-list, +tool docstring + `_SERVER_INSTRUCTIONS` updates, +exports |
| `tests/test_server.py` | +`TestDenCache` (8 tests) and `TestDenFunctions` (16 tests) |
| `tests/test_integration.py` | +`TestDenIntegration` (2 live tests) |

## Verified

- 258 unit tests pass (was 234; +24 new).
- 2 Den integration tests pass against https://den.denful.dev.
- `ruff check`, `ruff format --check`, and `mypy` are all clean.
- Live end-to-end via the MCP `nix` tool:
  - `action=search source=den query=aspects` → top hits are Aspects
    & Functors, Configure Aspects, and the `den.aspects` reference.
  - `action=info source=den query=guides/from-zero-to-den` → returns
    the From Zero to Den page with title, source URL, path, and
    body.
  - `action=stats source=den` → 55 total pages across 7 sections
    (explanation: 16, guides: 14, tutorials: 12, reference: 10, plus
    motivation / maintainers / overview singletons).
  - `action=browse source=den query=guides` → lists all 14 guide
    pages.

## Tradeoffs

- **No Pagefind / WASM.** Pagefind's bincode binary index is not
  portable; we crawl the rendered pages instead. Faster to implement,
  and the corpus is small enough that linear substring search is fine.
- **Substring scoring only.** No BM25 / fuzzy / snippets. Matches
  what nix-dev and noogle do today; can be upgraded later if the
  relevance isn't good enough in practice.
- **200KB body cap** on info output, matching nix-dev. Den pages
  are typically 5-50KB so this is plenty.
- **No `versions.json` handling** — the Den site is single-version
  and that endpoint returns `[]`.

Work created during Nix Taco Sprint: https://tacosprint.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Den documentation as a supported knowledge source, enabling search, browse, info, and stats for Den pages.
* **Enhancements**
  * Introduced an in-memory Den docs cache that discovers pages from Den’s overview, fetches them concurrently, normalizes links, and returns deterministic results.
  * Extended server routing and public exports so Den actions work end-to-end.
* **Bug Fixes**
  * Standardized Den missing-page handling versus other fetch/parsing failures, with consistent body truncation for info.
* **Tests**
  * Added unit and integration coverage for cache discovery/building and Den search/info/browse/stats behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->