### PR TITLE
fix(flake): drop x86_64-darwin from systems to unblock FlakeHub publish

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Compatibility
+
+- Intel macOS (`x86_64-darwin`) flake outputs have been removed because current nixpkgs marks a transitive development-shell dependency as broken on that platform, which prevented FlakeHub from evaluating and publishing the flake. Apple Silicon macOS (`aarch64-darwin`) and both supported Linux systems remain available.
+
+---
+
 # MCP-NixOS: v2.4.3 Release Notes - LLM Discoverability
 
 ## Overview

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 


### PR DESCRIPTION
Closes #137.

## Summary

`Publish tags to FlakeHub` has been failing for every release since v2.4.0 because FlakeHub's inspector walks every output of every system in the flake's `systems` list and trips over `arrow-cpp-23.0.0`, which is marked broken on `x86_64-darwin` in nixpkgs:

```
error: Refusing to evaluate package 'arrow-cpp-23.0.0' in
  .../pkgs/by-name/ar/arrow-cpp/package.nix:329 because it has problems:
  - broken: This package is broken.
```

We don't use arrow-cpp. It's only a transitive reference through the `devShells.x86_64-darwin.default` closure — our local CI doesn't walk dev shells this way, so it never sees it.

This PR drops `x86_64-darwin` from the flake-parts `systems` list in `flake.nix`. The remaining three systems (`x86_64-linux`, `aarch64-linux`, `aarch64-darwin`) are unaffected and the flake evaluates cleanly on all of them.

This aligns with the upstream direction: Nixpkgs 26.05 will be the last release to support x86_64-darwin, and more package-level breakage on that platform is expected.

## Tradeoffs considered (from the issue)

- **Option 2** (`arrow-cpp.meta.broken = false` overlay override) — rejected. Masks a real upstream brokenness and ties us to maintaining a custom override forever.
- **Option 3** (narrow the flake surface for FlakeHub) — rejected. `flakehub-push@main` has no input to skip devShells per system; it always walks everything.
- **Option 4** (do nothing) — rejected. Leaves the secondary registry broken indefinitely.

## Compatibility impact

- `packages.x86_64-darwin.default`, `packages.x86_64-darwin.mcp-nixos`, `packages.x86_64-darwin.docker`, `devShells.x86_64-darwin.default`, `devShells.x86_64-darwin.web`, and `apps.x86_64-darwin.*` are no longer present in the flake output.
- Anyone consuming those attrs directly from this flake on Intel Macs will see them vanish. FlakeHub consumers on `x86_64-darwin` would already be unable to resolve them today (the walk trips before they get there) so this is a no-op in practice for the secondary registry.
- PyPI, GHCR, and Docker Hub publishing are unaffected (those workflows already only build `x86_64-linux` and `aarch64-linux`).

## Verified

- `nix flake check --no-build --all-systems` — all 3 remaining systems evaluate cleanly.
- `nix flake show --json` — confirmed no `x86_64-darwin` keys in `packages`, `devShells`, or `apps`.
- `nix build .#packages.aarch64-darwin.default --no-link` — exit 0.
- `nix develop --command true` — exit 0.
- `uv run pytest tests/ -m "unit" --no-cov -q` — 234 passed (no Python impact expected, ran as a sanity check).
- Other CI workflows (`ci.yml`, `publish.yml`, `deploy-flakehub.yml`, `deploy-website.yml`) already only build `x86_64-linux` and `aarch64-linux`; no workflow changes needed.

## Suggestion for maintainer

Before cutting the next real release, please push a throwaway tag (e.g. `v2.4.4-rc1`) from this PR's branch and confirm the `Publish tags to FlakeHub` workflow runs green end-to-end. That's the only path that fully exercises the fix at the level where the original failure occurred.

A note about the dropped system in `RELEASE_NOTES.md` for the next release would also be helpful for any downstream consumer.

Work created during Nix Taco Sprint: https://tacosprint.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for Intel-based macOS systems. Apple Silicon-based macOS systems remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->