### PR TITLE
Add Beacon Agent Manifest for AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP-NixOS - Because Your AI Shouldn't Hallucinate Package Names
 
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/utensils%2Fmcp-nixos/badge.svg)](https://portal-five-phi-54.vercel.app/?q=nixos+mcp)
+
 [![CI](https://github.com/utensils/mcp-nixos/actions/workflows/ci.yml/badge.svg)](https://github.com/utensils/mcp-nixos/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/utensils/mcp-nixos/graph/badge.svg?token=kdcbgvq4Bh)](https://codecov.io/gh/utensils/mcp-nixos)
 [![PyPI](https://img.shields.io/pypi/v/mcp-nixos.svg)](https://pypi.org/project/mcp-nixos/)

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,14 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "utensils/mcp-nixos",
+  "name": "MCP-NixOS",
+  "description": "MCP server for accurate NixOS package and option lookups — no hallucinated package names.",
+  "capabilities": ["mcp-server", "nixos", "devops", "package-management", "claude"],
+  "interfaces": [
+    { "type": "python", "endpoint": "pip install mcp-nixos" },
+    { "type": "mcp", "endpoint": "https://github.com/utensils/mcp-nixos" }
+  ],
+  "source": "https://github.com/utensils/mcp-nixos",
+  "homepage": "https://github.com/utensils/mcp-nixos",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Beacon Agent Manifest (optional, ~2 min review)

[Beacon](https://portal-five-phi-54.vercel.app) is an open agent registry (33k+ MCP servers & agents). You are already indexed from GitHub.

This PR adds:
- **`beacon.json`** — [open v0.1 standard](https://github.com/enrichgateagent-png/beacon-agent-manifest) for machine-readable agent discovery (Claude, Cursor MCP, etc.)
- **README badge** — live verification link back to your listing

No API keys, no accounts. Hosting `beacon.json` in your repo is the verification (location = proof).

If merged, Beacon auto-upgrades your listing to **verified manifest** on the next scan.

Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest · [llms.txt](https://registry-ruby.vercel.app/llms.txt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Beacon Verified” badge and link to the project README.
  * Added a manifest describing the MCP server, its capabilities, installation options, source repository, homepage, and MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->