### PR TITLE
feat: add NVF as an options source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ result
 *.swo
 *~
 .vscode/
+.zed/
 
 # MCP local configuration
 .mcp-nix.json

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -148,7 +148,7 @@ const nixToolParams = Type.Object({
 		description:
 			"One of: search, info, stats, browse, channels, flake-inputs, cache, store. " +
 			"search = keyword lookup; info = details for a specific name; " +
-			"browse = walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only); " +
+			"browse = walk an option hierarchy by prefix (home-manager/darwin/nixvim/nvf/noogle only); " +
 			"store = read files or list directories at an explicit /nix/store/ path.",
 	}),
 	query: Type.Optional(
@@ -163,7 +163,7 @@ const nixToolParams = Type.Object({
 		Type.String({
 			description:
 				"Data source for search/info/stats/browse/cache. One of: nixos (default), " +
-				"home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. " +
+				"home-manager, darwin, flakes, flakehub, nixvim, nvf, wiki, nix-dev, noogle, nixhub. " +
 				"For action=flake-inputs, this may instead be a path to a flake directory; " +
 				"omit/default to use the current project. Ignored by action=store.",
 		}),
@@ -196,7 +196,7 @@ const nixToolParams = Type.Object({
 type NixToolParams = Static<typeof nixToolParams>;
 
 const nixToolDescription = [
-	"Query live NixOS data (packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, Noogle, NixHub, binary cache).",
+	"Query live NixOS data (packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, NVF, Noogle, NixHub, binary cache).",
 	"",
 	"Examples (copy the JSON shape exactly):",
 	'  Search NixOS packages:    {"action": "search", "query": "firefox"}',
@@ -205,6 +205,9 @@ const nixToolDescription = [
 	'  Get an option:            {"action": "info", "query": "services.nginx.enable", "type": "option"}',
 	'  Search Home Manager:      {"action": "search", "query": "git", "source": "home-manager"}',
 	'  Browse HM option tree:    {"action": "browse", "query": "programs", "source": "home-manager"}',
+	'  Search NVF options:       {"action": "search", "query": "languages.nix", "source": "nvf"}',
+	'  Inspect an NVF option:    {"action": "info", "query": "programs.nvf.vim.languages.nix.enable", "source": "nvf"}',
+	'  Browse NVF options:       {"action": "browse", "query": "vim.languages.nix", "source": "nvf"}',
 	'  Search the wiki:          {"action": "search", "query": "zfs", "source": "wiki"}',
 	'  Search nix.dev docs:      {"action": "search", "query": "flakes", "source": "nix-dev"}',
 	'  Read a nix.dev page:      {"action": "info", "query": "tutorials/nix-language", "source": "nix-dev"}',
@@ -215,7 +218,8 @@ const nixToolDescription = [
 	"",
 	"Notes:",
 	"  - To search NixOS options, use action=search with type=options. Do NOT use action=browse for source=nixos.",
-	"  - action=browse walks a pre-indexed option tree and only supports home-manager, darwin, nixvim, or noogle.",
+	"  - action=browse walks a pre-indexed option tree and only supports home-manager, darwin, nixvim, nvf, or noogle.",
+	"  - NVF's canonical option paths are vim.*; programs.nvf.vim.* and programs.nvf.settings.vim.* are accepted aliases.",
 	"  - For source=nix-dev, action=info returns the page markdown. Query accepts a bare docname ('tutorials/nix-language'), the URL printed by nix-dev search ('https://nix.dev/tutorials/nix-language'), or a rendered '.html' URL.",
 	"  - Omit optional parameters; don't pass empty strings.",
 	"  - For package version history use the separate nix_versions tool.",
@@ -226,12 +230,12 @@ const nixTool = defineTool({
 	label: "NixOS",
 	description: nixToolDescription,
 	promptSnippet:
-		"Prefer the nix tool over web search for NixOS packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, Noogle, flake inputs, and binary cache status.",
+		"Prefer the nix tool over web search for NixOS packages, options, flakes, wiki, nix.dev, Home Manager, nix-darwin, Nixvim, NVF, Noogle, flake inputs, and binary cache status.",
 	promptGuidelines: [
 		"Prefer the nix tool over web search for NixOS-related package, option, flake, wiki, nix.dev, and cache questions.",
 		'To search NixOS options: {"action": "search", "query": "<keyword>", "type": "options"}.',
 		'To inspect a NixOS option: {"action": "info", "query": "<option.path>", "type": "option"}.',
-		"action=browse is for walking option prefixes in home-manager, darwin, nixvim, or noogle only — never with source=nixos.",
+		"action=browse is for walking option prefixes in home-manager, darwin, nixvim, nvf, or noogle only — never with source=nixos.",
 	],
 	parameters: nixToolParams,
 	async execute(_toolCallId: string, params: NixToolParams, signal: AbortSignal | undefined) {

--- a/.pi/extensions/mcp-nixos.ts
+++ b/.pi/extensions/mcp-nixos.ts
@@ -219,7 +219,7 @@ const nixToolDescription = [
 	"Notes:",
 	"  - To search NixOS options, use action=search with type=options. Do NOT use action=browse for source=nixos.",
 	"  - action=browse walks a pre-indexed option tree and only supports home-manager, darwin, nixvim, nvf, or noogle.",
-	"  - NVF's canonical option paths are vim.*; programs.nvf.vim.* and programs.nvf.settings.vim.* are accepted aliases.",
+	"  - NVF's canonical paths are vim.*; programs.nvf.vim.* is shorthand and programs.nvf.settings.vim.* is the module-path alias.",
 	"  - For source=nix-dev, action=info returns the page markdown. Query accepts a bare docname ('tutorials/nix-language'), the URL printed by nix-dev search ('https://nix.dev/tutorials/nix-language'), or a rendered '.html' URL.",
 	"  - Omit optional parameters; don't pass empty strings.",
 	"  - For package version history use the separate nix_versions tool.",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-time information about NixOS packages, configuration options, Home Manager, nix-darwin, and flakes. It prevents AI assistants from hallucinating about NixOS package names and configurations by querying official APIs and documentation.
+MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-time information about NixOS packages, configuration options, Home Manager, nix-darwin, Nixvim, NVF, and flakes. It prevents AI assistants from hallucinating about NixOS package names and configurations by querying official APIs and documentation.
 
 ## Project Structure & Module Organization
 
 - `mcp_nixos/` - Contains the MCP server implementation.
   - `mcp_nixos/server.py` - MCP tools, tool routing, and main entry point.
   - `mcp_nixos/config.py` - Configuration constants (API URLs, auth, limits).
-  - `mcp_nixos/caches.py` - Cache implementations (channels, nixvim, noogle, nix.dev).
+  - `mcp_nixos/caches.py` - Process-local cache implementations (channels, nixvim, NVF, noogle, nix.dev).
   - `mcp_nixos/utils.py` - Shared utility functions (HTML parsing, formatting, file I/O).
   - `mcp_nixos/sources/` - Data source implementations (one module per source):
     - `base.py` - Channel helpers, Elasticsearch queries, browsing utilities.
@@ -23,6 +23,7 @@ MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-
     - `wiki.py` - NixOS Wiki search.
     - `nixdev.py` - nix.dev documentation.
     - `nixvim.py` - Nixvim options.
+    - `nvf.py` - NVF options, path normalization, and query actions.
     - `noogle.py` - Noogle function search.
     - `nixhub.py` - NixHub API + binary cache status.
     - `flake_inputs.py` - Local flake inputs via nix store.
@@ -38,7 +39,7 @@ MCP-NixOS is a Model Context Protocol (MCP) server that provides accurate, real-
 The project is a FastMCP 3.x server (async) with a modular structure (Python 3.11+). The server is organized into focused modules: `server.py` handles MCP tools and routing, `sources/` contains per-source implementations, `config.py` defines constants, `caches.py` manages cached data, and `utils.py` provides shared utilities.
 
 Only **2 MCP tools** are exposed (consolidated from 17 in v1.0):
-- `nix` - Unified query tool for search/info/stats/browse/channels/flake-inputs/cache across all sources. `options` is accepted as a silent alias for `browse` (legacy).
+- `nix` - Unified query tool for search/info/stats/browse/channels/flake-inputs/cache/store across all sources. `options` is accepted as a silent alias for `browse` (legacy).
 - `nix_versions` - Package version history from NixHub.io.
 
 ### Data Sources
@@ -46,6 +47,8 @@ Only **2 MCP tools** are exposed (consolidated from 17 in v1.0):
 - NixOS packages/options: Elasticsearch API at search.nixos.org
 - Home Manager options: HTML parsing from official docs
 - nix-darwin options: HTML parsing from official docs
+- Nixvim options: NuschtOS search metadata
+- NVF options: HTML parsing from the latest published unstable options documentation
 - Package versions: NixHub.io API (search.devbox.sh)
 - Package metadata: NixHub.io API for license, homepage, store paths
 - Binary cache status: cache.nixos.org narinfo queries
@@ -168,7 +171,7 @@ pytest tests/ -k "nixos" -v
 
 1. **Channel Resolution**: The server dynamically discovers available NixOS channels on startup. "stable" always maps to the current stable release.
 2. **Error Handling**: All tools return helpful plain text error messages. API failures gracefully degrade.
-3. **No Caching**: Version 1.0+ removed all caching for simplicity. All queries hit live APIs.
+3. **Process-local Caching**: There is no persistent cache or database. Catalogue-style sources such as Nixvim, NVF, Noogle, and nix.dev are cached in memory for the lifetime of the server process; other queries hit live APIs.
 4. **Async Everything**: Version 1.0.1 migrated to FastMCP (currently FastMCP 3.x; `fastmcp>=3.2.0` in `pyproject.toml`). All tools are async functions. All blocking HTTP calls and file I/O are wrapped in `asyncio.to_thread()` to prevent blocking the event loop.
 5. **Plain Text Output**: All responses are formatted as human-readable plain text. Never return raw JSON or XML to users.
 6. **Environment Variables**:
@@ -181,6 +184,7 @@ pytest tests/ -k "nixos" -v
 7. **Flake Inputs**: The `flake-inputs` action requires nix to be installed locally. It uses `nix flake archive --json` to discover inputs and their store paths, with security validation to ensure paths stay within `/nix/store/`.
 8. **Binary Cache Status**: The `cache` action queries cache.nixos.org to check if packages have pre-built binaries. It uses NixHub to resolve package versions to store paths, then checks narinfo availability.
 9. **NixHub Source**: The `nixhub` source provides rich package metadata including license, homepage, programs, and store paths via the search.devbox.sh API.
+10. **NVF Source**: The `nvf` source tracks NVF's latest published unstable options. Its canonical names are `vim.*`; callers may also use `programs.nvf.vim.*` or `programs.nvf.settings.vim.*`, which normalize to the canonical path before search, info, or browse operations.
 
 ## Commit, PR, & Release Guidelines
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ An MCP server providing accurate, real-time information about:
 - **Home Manager** - 5K+ options for dotfile enthusiasts
 - **nix-darwin** - 1K+ macOS settings Apple doesn't document
 - **Nixvim** - 5K+ options for Neovim configuration via [NuschtOS search](https://github.com/NuschtOS/search)
+- **NVF** - 2.4K+ Neovim options from its [published unstable documentation](https://nvf.notashelf.dev/options.html)
 - **FlakeHub** - 600+ flakes from [FlakeHub.com](https://flakehub.com) registry
 - **Noogle** - 2K+ Nix functions with type signatures via [noogle.dev](https://noogle.dev)
 - **NixOS Wiki** - Community documentation and guides from [wiki.nixos.org](https://wiki.nixos.org)
@@ -148,7 +149,7 @@ nix(action, query, source, type, channel, limit)
 | `search` | Search packages, options, programs, or flakes |
 | `info` | Get detailed info about a package or option |
 | `stats` | Get counts and categories |
-| `options` | Browse Home Manager/Darwin options by prefix |
+| `browse` | Browse Home Manager, Darwin, Nixvim, NVF, or Noogle by prefix (legacy alias: `options`) |
 | `channels` | List available NixOS channels |
 | `flake-inputs` | Explore local flake inputs from Nix store |
 | `cache` | Check binary cache status for packages |
@@ -161,10 +162,15 @@ nix(action, query, source, type, channel, limit)
 | `flakes` | Community flakes (search.nixos.org) |
 | `flakehub` | FlakeHub registry (flakehub.com) |
 | `nixvim` | Nixvim Neovim configuration options |
+| `nvf` | NVF Neovim configuration options (latest unstable docs) |
 | `noogle` | Nix function signatures and docs (noogle.dev) |
 | `wiki` | NixOS Wiki articles (wiki.nixos.org) |
 | `nix-dev` | Official Nix documentation (nix.dev) |
 | `nixhub` | Package metadata and store paths (nixhub.io) |
+
+NVF results use canonical `vim.*` option paths. Queries may also use the shorthand
+`programs.nvf.vim.*` or the NixOS/Home Manager module path
+`programs.nvf.settings.vim.*`; both are normalized automatically.
 
 **Examples:**
 
@@ -179,13 +185,22 @@ nix(action="info", query="firefox", source="nixos", type="package")
 nix(action="search", query="git", source="home-manager")
 
 # Browse darwin options
-nix(action="options", source="darwin", query="system.defaults")
+nix(action="browse", source="darwin", query="system.defaults")
 
 # Search Nixvim options
 nix(action="search", query="telescope", source="nixvim")
 
 # Get Nixvim option info
 nix(action="info", query="plugins.telescope.enable", source="nixvim")
+
+# Search NVF options
+nix(action="search", query="vim.languages.nix", source="nvf")
+
+# Get NVF option info using a module wrapper path
+nix(action="info", query="programs.nvf.settings.vim.languages.nix.enable", source="nvf")
+
+# Browse NVF options below a prefix
+nix(action="browse", query="programs.nvf.vim.languages.nix", source="nvf")
 
 # Search FlakeHub
 nix(action="search", query="nixpkgs", source="flakehub")
@@ -200,7 +215,7 @@ nix(action="search", query="mapAttrs", source="noogle")
 nix(action="info", query="lib.attrsets.mapAttrs", source="noogle")
 
 # Browse Noogle function categories
-nix(action="options", source="noogle", query="lib.strings")
+nix(action="browse", source="noogle", query="lib.strings")
 
 # Search NixOS Wiki
 nix(action="search", query="nvidia", source="wiki")
@@ -349,6 +364,7 @@ mypy mcp_nixos/      # Type check
 - **[Noogle](https://noogle.dev)** - Nix function search engine
 - **[NuschtOS](https://github.com/NuschtOS/search)** - Static option search infrastructure powering Nixvim support
 - **[Nixvim](https://github.com/nix-community/nixvim)** - Neovim configuration framework for Nix
+- **[NVF](https://github.com/NotAShelf/nvf)** - Neovim configuration framework and published option catalogue
 
 ## License
 

--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -1,10 +1,15 @@
 """Cache classes for MCP-NixOS server."""
 
+from __future__ import annotations
+
 import json
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
 
 import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from .config import (
     FALLBACK_CHANNELS,
@@ -13,8 +18,12 @@ from .config import (
     NIXOS_AUTH,
     NIXVIM_META_BASE,
     NOOGLE_API,
+    NVF_OPTIONS_URL,
     APIError,
 )
+
+if TYPE_CHECKING:
+    from .sources.nvf import NvfOption
 
 
 class ChannelCache:
@@ -153,6 +162,99 @@ class NixvimCache:
 
 
 nixvim_cache = NixvimCache()
+
+
+class NvfCache:
+    """Cache NVF's canonical ``vim.*`` options from its published docs."""
+
+    def __init__(self) -> None:
+        self.options: list[NvfOption] | None = None
+
+    @staticmethod
+    def _extract_text(option: Tag, selector: str, label: str = "") -> str:
+        """Extract a field as readable plain text, preserving code blocks."""
+        field = option.select_one(selector)
+        if field is None:
+            return ""
+
+        preserve_lines = field.find("pre") is not None
+        separator = "\n" if preserve_lines else " "
+        value = field.get_text(separator=separator, strip=True)
+        if label and value.startswith(label):
+            value = value[len(label) :].lstrip()
+
+        if preserve_lines:
+            return "\n".join(line.rstrip() for line in value.splitlines()).strip()
+        return " ".join(value.split())
+
+    @classmethod
+    def _parse_options(cls, html: bytes | str) -> list[NvfOption]:
+        """Parse normalized NVF option records from ``options.html``."""
+        soup = BeautifulSoup(html, "html.parser")
+        options: list[NvfOption] = []
+
+        for option in soup.select(".options-container .option"):
+            anchor = option.select_one(".option-name .option-anchor")
+            if anchor is None:
+                continue
+
+            name = anchor.get_text(" ", strip=True)
+            if name != "vim" and not name.startswith("vim."):
+                continue
+
+            declarations: list[str] = []
+            for declaration in option.select(".option-declared a[href]"):
+                href = declaration.get("href")
+                if isinstance(href, str):
+                    declarations.append(urljoin(NVF_OPTIONS_URL, href))
+
+            anchor_href = anchor.get("href")
+            if isinstance(anchor_href, str):
+                option_url = urljoin(NVF_OPTIONS_URL, anchor_href)
+            else:
+                option_id = option.get("id")
+                fragment = f"#{option_id}" if isinstance(option_id, str) and option_id else ""
+                option_url = f"{NVF_OPTIONS_URL}{fragment}"
+
+            options.append(
+                {
+                    "name": name,
+                    "type": cls._extract_text(option, ".option-type", "Type:"),
+                    "description": cls._extract_text(option, ".option-description"),
+                    "default": cls._extract_text(option, ".option-default", "Default:"),
+                    "example": cls._extract_text(option, ".option-example", "Example:"),
+                    "declarations": declarations,
+                    "url": option_url,
+                }
+            )
+
+        return options
+
+    def get_options(self) -> list[NvfOption]:
+        """Fetch, validate, and cache the latest published NVF options."""
+        if self.options is not None:
+            return self.options
+
+        try:
+            response = requests.get(NVF_OPTIONS_URL, timeout=30)
+            response.raise_for_status()
+            options = self._parse_options(response.content)
+            if not options:
+                raise APIError("Failed to parse NVF options: no canonical vim.* options found")
+
+            self.options = options
+            return self.options
+        except requests.Timeout as exc:
+            raise APIError("Timeout fetching NVF options") from exc
+        except requests.RequestException as exc:
+            raise APIError(f"Failed to fetch NVF options: {exc}") from exc
+        except APIError:
+            raise
+        except Exception as exc:
+            raise APIError(f"Failed to parse NVF options: {exc}") from exc
+
+
+nvf_cache = NvfCache()
 
 
 class NixDevCache:

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -31,7 +31,9 @@ FALLBACK_CHANNELS = {
     "beta": "latest-44-nixos-25.11",
 }
 
-HOME_MANAGER_URL = "https://nix-community.github.io/home-manager/options.xhtml"
+# Home Manager's option docs are split across mdBook pages. The print view keeps
+# the complete option catalogue in one document for search, info, browse, and stats.
+HOME_MANAGER_URL = "https://nix-community.github.io/home-manager/print.html"
 DARWIN_URL = "https://nix-darwin.github.io/nix-darwin/manual/index.html"
 FLAKE_INDEX = "latest-44-group-manual"
 

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -43,6 +43,9 @@ FLAKEHUB_USER_AGENT = f"mcp-nixos/{__version__}"
 # Credit: https://github.com/NuschtOS/search - Simple and fast static-page NixOS option search
 NIXVIM_META_BASE = "https://nix-community.github.io/nixvim/search/meta"
 
+# NVF options from the latest published (unstable) documentation.
+NVF_OPTIONS_URL = "https://nvf.notashelf.dev/options.html"
+
 # NixOS Wiki (MediaWiki API)
 WIKI_API = "https://wiki.nixos.org/w/api.php"
 
@@ -71,6 +74,7 @@ KNOWN_SOURCES = {
     "flakes",
     "flakehub",
     "nixvim",
+    "nvf",
     "wiki",
     "nix-dev",
     "noogle",

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -5,6 +5,7 @@ Provides search and query capabilities for:
 - NixOS packages, options, and programs via Elasticsearch API
 - Home Manager configuration options via HTML documentation parsing
 - nix-darwin (macOS) configuration options via HTML documentation parsing
+- NVF Neovim configuration options via its published option catalogue
 
 All responses are formatted as human-readable plain text for optimal LLM interaction.
 """
@@ -26,10 +27,12 @@ from .caches import (
     NixDevCache,
     NixvimCache,
     NoogleCache,
+    NvfCache,
     channel_cache,
     nixdev_cache,
     nixvim_cache,
     noogle_cache,
+    nvf_cache,
 )
 from .config import (
     BASE_CHANNELS,
@@ -51,6 +54,7 @@ from .config import (
     NIXOS_AUTH,
     NIXVIM_META_BASE,
     NOOGLE_API,
+    NVF_OPTIONS_URL,
     WIKI_API,
     APIError,
     DocumentParseError,
@@ -60,6 +64,8 @@ from .sources import (
     _browse_nixvim_options,
     # Noogle
     _browse_noogle_options,
+    # NVF
+    _browse_nvf_options,
     # Base
     _browse_options,
     # NixHub
@@ -76,6 +82,7 @@ from .sources import (
     _flake_inputs_read,
     _flatten_inputs,
     _format_nixvim_option,
+    _format_nvf_option,
     _get_flake_inputs,
     _get_noogle_aliases,
     _get_noogle_description,
@@ -94,6 +101,7 @@ from .sources import (
     _info_nixos,
     _info_nixvim,
     _info_noogle,
+    _info_nvf,
     # Wiki
     _info_wiki,
     _list_channels,
@@ -109,6 +117,7 @@ from .sources import (
     _search_nixos,
     _search_nixvim,
     _search_noogle,
+    _search_nvf,
     _search_wiki,
     _stats_darwin,
     _stats_flakehub,
@@ -117,6 +126,7 @@ from .sources import (
     _stats_nixos,
     _stats_nixvim,
     _stats_noogle,
+    _stats_nvf,
     _store_ls,
     _store_read,
     es_query,
@@ -146,7 +156,7 @@ from .utils import (
 # intent-focused, and explicit about triggers; see GH #146.
 _SERVER_INSTRUCTIONS = (
     "Use this server for any question about nixpkgs packages, NixOS / home-manager / "
-    "nix-darwin / nixvim options, flakes, FlakeHub, channels, the binary cache, store "
+    "nix-darwin / nixvim / NVF options, flakes, FlakeHub, channels, the binary cache, store "
     "paths, or the NixOS wiki and nix.dev docs. It queries live APIs (search.nixos.org, "
     "NixHub, FlakeHub, cache.nixos.org) and is faster and more current than `nix search`, "
     "scraping search.nixos.org by hand, or running `gh api` against NixOS/nixpkgs.\n\n"
@@ -156,7 +166,7 @@ _SERVER_INSTRUCTIONS = (
     "data lags nixpkgs by months.\n\n"
     "Two tools are exposed:\n"
     "- `nix` — unified search/info/stats/browse/channels/flake-inputs/cache/store across "
-    "NixOS, Home Manager, nix-darwin, Nixvim, flakes, FlakeHub, NixHub, the NixOS wiki, "
+    "NixOS, Home Manager, nix-darwin, Nixvim, NVF, flakes, FlakeHub, NixHub, the NixOS wiki, "
     "nix.dev, and Noogle. For package version *history* pair with `nix_versions`.\n"
     "- `nix_versions` — commit-accurate history from NixHub (which nixpkgs commit "
     "shipped version X, what attribute path, which platforms).\n\n"
@@ -165,6 +175,7 @@ _SERVER_INSTRUCTIONS = (
     '  "which channels are available?"      → nix {"action":"channels"}\n'
     '  "search NixOS options for X"         → nix {"action":"search","query":"X","type":"options"}\n'
     '  "home-manager option for X"          → nix {"action":"search","source":"home-manager","query":"X"}\n'
+    '  "NVF option for X"                   → nix {"action":"search","source":"nvf","query":"X"}\n'
     '  "does X have a binary cache?"        → nix {"action":"cache","query":"X"}\n'
     '  "read /nix/store/<path>"             → nix {"action":"store","type":"read","query":"/nix/store/<path>"}\n'
     '  "which commit shipped X version Y?"  → nix_versions {"package":"X","version":"Y"}\n'
@@ -200,7 +211,7 @@ async def nix(
         str,
         "One of: search, info, stats, browse, channels, flake-inputs, cache, store. "
         "Use 'search' for keyword lookup, 'info' for details about a specific name, "
-        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/noogle only). "
+        "'browse' to walk an option hierarchy by prefix (home-manager/darwin/nixvim/nvf/noogle only). "
         "'store' reads files or lists directories at an explicit /nix/store/ path.",
     ],
     query: Annotated[
@@ -212,7 +223,7 @@ async def nix(
     source: Annotated[
         str,
         "Data source for search/info/stats/browse/cache. One of: nixos (default), "
-        "home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub. "
+        "home-manager, darwin, flakes, flakehub, nixvim, nvf, wiki, nix-dev, noogle, nixhub. "
         "For action=flake-inputs, this may instead be a path to a flake directory; "
         "omit/default to use the current project. Ignored by action=store.",
     ] = "nixos",
@@ -228,7 +239,7 @@ async def nix(
     version: Annotated[str, "Only used by action=cache. Package version (default: latest)."] = "latest",
     system: Annotated[str, "Only used by action=cache. System arch e.g. x86_64-linux. Empty for all."] = "",
 ) -> str:
-    """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, Wiki, nix.dev, Noogle, NixHub.
+    """Query NixOS, Home Manager, Darwin, FlakeHub, flakes, Nixvim, NVF, Wiki, nix.dev, Noogle, NixHub.
 
     Use this tool for anything touching nixpkgs, Nix channels, flakes, NixOS / home-manager /
     darwin options, the binary cache, or /nix/store paths — even when you think you know the
@@ -246,6 +257,7 @@ async def nix(
       "home-manager option for X"         → {"action": "search", "query": "X", "source": "home-manager"}
       "darwin option for X"               → {"action": "search", "query": "X", "source": "darwin"}
       "nixvim option for X"               → {"action": "search", "query": "X", "source": "nixvim"}
+      "NVF option for X"                  → {"action": "search", "query": "X", "source": "nvf"}
       "what programs does pkg X provide?" → {"action": "search", "query": "X", "type": "programs"}
       "count packages/options"            → {"action": "stats"}
       "browse hm option tree under P"     → {"action": "browse", "query": "P", "source": "home-manager"}
@@ -264,7 +276,9 @@ async def nix(
     Notes:
       - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
         for source=nixos — browse is for walking a pre-indexed option tree and only works with
-        home-manager, darwin, nixvim, or noogle.
+        home-manager, darwin, nixvim, nvf, or noogle.
+      - For source=nvf, canonical option paths are vim.*. The NixOS/Home Manager wrapper paths
+        programs.nvf.vim.* and programs.nvf.settings.vim.* are normalized automatically.
       - For source=nix-dev, action=info returns the page markdown. The query may be a bare
         docname like "tutorials/nix-language", the URL printed by nix-dev search
         ("https://nix.dev/tutorials/nix-language"), or a rendered ".html" URL.
@@ -308,6 +322,8 @@ async def nix(
             return await asyncio.to_thread(_search_flakehub, query, limit)
         elif source == "nixvim":
             return await asyncio.to_thread(_search_nixvim, query, limit)
+        elif source == "nvf":
+            return await asyncio.to_thread(_search_nvf, query, limit)
         elif source == "wiki":
             return await asyncio.to_thread(_search_wiki, query, limit)
         elif source == "nix-dev":
@@ -319,7 +335,7 @@ async def nix(
         else:
             return error(
                 f"Unknown source: {source!r}. Must be one of: "
-                "nixos, home-manager, darwin, flakes, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, nvf, wiki, nix-dev, noogle, nixhub."
             )
 
     elif action == "info":
@@ -346,6 +362,8 @@ async def nix(
             return await asyncio.to_thread(_info_flakehub, query)
         elif source == "nixvim":
             return await asyncio.to_thread(_info_nixvim, query)
+        elif source == "nvf":
+            return await asyncio.to_thread(_info_nvf, query)
         elif source == "wiki":
             return await asyncio.to_thread(_info_wiki, query)
         elif source == "nix-dev":
@@ -357,7 +375,7 @@ async def nix(
         else:
             return error(
                 f"Unknown source: {source!r}. For action=info, must be one of: "
-                "nixos, home-manager, darwin, flakehub, nixvim, wiki, nix-dev, noogle, nixhub."
+                "nixos, home-manager, darwin, flakehub, nixvim, nvf, wiki, nix-dev, noogle, nixhub."
             )
 
     elif action == "stats":
@@ -373,6 +391,8 @@ async def nix(
             return await asyncio.to_thread(_stats_flakehub)
         elif source == "nixvim":
             return await asyncio.to_thread(_stats_nixvim)
+        elif source == "nvf":
+            return await asyncio.to_thread(_stats_nvf)
         elif source == "noogle":
             return await asyncio.to_thread(_stats_noogle)
         elif source in ["wiki", "nix-dev", "nixhub"]:
@@ -380,7 +400,7 @@ async def nix(
         else:
             return error(
                 f"Unknown source: {source!r}. For action=stats, must be one of: "
-                "nixos, home-manager, darwin, flakes, flakehub, nixvim, noogle."
+                "nixos, home-manager, darwin, flakes, flakehub, nixvim, nvf, noogle."
             )
 
     elif action == "browse":
@@ -391,13 +411,15 @@ async def nix(
                 "To get a specific option's details, use: "
                 '{"action": "info", "query": "services.nginx.enable", "type": "option"}.'
             )
-        if source not in ["home-manager", "darwin", "nixvim", "noogle"]:
+        if source not in ["home-manager", "darwin", "nixvim", "nvf", "noogle"]:
             return error(
-                "action=browse only supports source in: home-manager, darwin, nixvim, noogle. "
+                "action=browse only supports source in: home-manager, darwin, nixvim, nvf, noogle. "
                 'Example: {"action": "browse", "query": "programs", "source": "home-manager"}'
             )
         if source == "nixvim":
             return await asyncio.to_thread(_browse_nixvim_options, query)
+        if source == "nvf":
+            return await asyncio.to_thread(_browse_nvf_options, query)
         if source == "noogle":
             return await asyncio.to_thread(_browse_noogle_options, query)
         return await asyncio.to_thread(_browse_options, source, query)
@@ -638,6 +660,7 @@ __all__ = [
     "FLAKEHUB_API",
     "FLAKEHUB_USER_AGENT",
     "NIXVIM_META_BASE",
+    "NVF_OPTIONS_URL",
     "WIKI_API",
     "NIXDEV_SEARCH_INDEX",
     "NIXDEV_BASE_URL",
@@ -653,10 +676,12 @@ __all__ = [
     "NixvimCache",
     "NixDevCache",
     "NoogleCache",
+    "NvfCache",
     "channel_cache",
     "nixvim_cache",
     "nixdev_cache",
     "noogle_cache",
+    "nvf_cache",
     # Utility functions
     "strip_html",
     "error",
@@ -706,6 +731,12 @@ __all__ = [
     "_format_nixvim_option",
     "_stats_nixvim",
     "_browse_nixvim_options",
+    # NVF functions
+    "_search_nvf",
+    "_info_nvf",
+    "_format_nvf_option",
+    "_stats_nvf",
+    "_browse_nvf_options",
     # Noogle functions
     "_get_noogle_function_path",
     "_get_noogle_type_signature",

--- a/mcp_nixos/server.py
+++ b/mcp_nixos/server.py
@@ -277,8 +277,8 @@ async def nix(
       - To search NixOS *options*, use action=search with type=options. Do NOT use action=browse
         for source=nixos — browse is for walking a pre-indexed option tree and only works with
         home-manager, darwin, nixvim, nvf, or noogle.
-      - For source=nvf, canonical option paths are vim.*. The NixOS/Home Manager wrapper paths
-        programs.nvf.vim.* and programs.nvf.settings.vim.* are normalized automatically.
+      - For source=nvf, canonical option paths are vim.*. The shorthand programs.nvf.vim.* and
+        NixOS/Home Manager module path programs.nvf.settings.vim.* are normalized automatically.
       - For source=nix-dev, action=info returns the page markdown. The query may be a bare
         docname like "tutorials/nix-language", the URL printed by nix-dev search
         ("https://nix.dev/tutorials/nix-language"), or a rendered ".html" URL.

--- a/mcp_nixos/sources/__init__.py
+++ b/mcp_nixos/sources/__init__.py
@@ -98,6 +98,15 @@ from .noogle import (
     _stats_noogle,
 )
 
+# NVF options
+from .nvf import (
+    _browse_nvf_options,
+    _format_nvf_option,
+    _info_nvf,
+    _search_nvf,
+    _stats_nvf,
+)
+
 # Direct /nix/store path access
 from .store import (
     _store_ls,
@@ -149,6 +158,12 @@ __all__ = [
     "_format_nixvim_option",
     "_stats_nixvim",
     "_browse_nixvim_options",
+    # NVF
+    "_search_nvf",
+    "_info_nvf",
+    "_format_nvf_option",
+    "_stats_nvf",
+    "_browse_nvf_options",
     # Noogle
     "_get_noogle_function_path",
     "_get_noogle_type_signature",

--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -231,7 +231,7 @@ def _browse_options(source: str, prefix: str) -> str:
                 results.append("")
             return "\n".join(results).strip()
         else:
-            options = parse_html_options(url, limit=5000)
+            options = parse_html_options(url, limit=None if source == "home-manager" else 5000)
             categories: dict[str, int] = {}
             for opt in options:
                 name = opt["name"]

--- a/mcp_nixos/sources/home_manager.py
+++ b/mcp_nixos/sources/home_manager.py
@@ -48,7 +48,7 @@ def _info_home_manager(name: str) -> str:
 def _stats_home_manager() -> str:
     """Get Home Manager option counts and top categories."""
     try:
-        options = parse_html_options(HOME_MANAGER_URL, limit=5000)
+        options = parse_html_options(HOME_MANAGER_URL, limit=None)
         if not options:
             return error("Failed to fetch Home Manager statistics")
 

--- a/mcp_nixos/sources/nvf.py
+++ b/mcp_nixos/sources/nvf.py
@@ -1,0 +1,79 @@
+"""Contract and shared helpers for the NVF options source.
+
+NVF's standalone/flake interface publishes its option catalogue under
+``vim.*``. The NixOS and Home Manager modules wrap the same catalogue under
+``programs.nvf.settings.vim.*``. MCP callers may also use the shorter
+``programs.nvf.vim.*`` spelling; all supported wrapper paths normalize to the
+canonical ``vim.*`` form before lookup or prefix browsing.
+
+The source tracks NVF's latest published unstable documentation and supports
+the existing ``search``, ``info``, ``browse``, and ``stats`` actions. Network
+loading and action implementations are added in later milestones.
+"""
+
+from typing import Final, TypedDict
+
+NVF_SOURCE: Final = "nvf"
+NVF_DISPLAY_NAME: Final = "NVF"
+NVF_DOCS_TRACK: Final = "unstable"
+NVF_CANONICAL_ROOT: Final = "vim"
+NVF_SUPPORTED_ACTIONS: Final[frozenset[str]] = frozenset({"search", "info", "browse", "stats"})
+
+# Longest aliases come first to make the intended precedence explicit. Each
+# alias names the root itself (without a trailing dot), allowing both a full
+# option path and a browse prefix such as ``programs.nvf.vim`` to normalize.
+NVF_OPTION_ROOT_ALIASES: Final[tuple[str, ...]] = (
+    "config.programs.nvf.settings.vim",
+    "programs.nvf.settings.vim",
+    "programs.nvf.vim",
+)
+
+
+class NvfOption(TypedDict):
+    """Normalized option record shared by NVF cache and source operations."""
+
+    name: str
+    type: str
+    description: str
+    default: str
+    example: str
+    declarations: list[str]
+    url: str
+
+
+def normalize_nvf_option_path(value: str) -> str:
+    """Normalize a canonical or wrapped NVF option path.
+
+    Only recognized option roots are rewritten. Ordinary keyword searches,
+    unknown paths, and wrapper-only options such as ``programs.nvf.enable``
+    are returned unchanged so later search logic can handle them honestly.
+    Prefix comparison is case-insensitive while the unmatched suffix keeps
+    its original spelling.
+    """
+    path = value.strip()
+    path_lower = path.lower()
+
+    for alias in NVF_OPTION_ROOT_ALIASES:
+        alias_lower = alias.lower()
+        if path_lower == alias_lower:
+            return NVF_CANONICAL_ROOT
+        if path_lower.startswith(alias_lower + "."):
+            return NVF_CANONICAL_ROOT + path[len(alias) :]
+
+    return path
+
+
+def nvf_option_category(name: str) -> str:
+    """Return a useful browse/stats category for an NVF option path.
+
+    Since nearly every public NVF option begins with ``vim``, the first two
+    path components form the category (for example ``vim.languages``).
+    Non-canonical names fall back to their first component.
+    """
+    normalized = normalize_nvf_option_path(name)
+    parts = normalized.split(".") if normalized else []
+    if not parts:
+        return ""
+    if parts[0].lower() == NVF_CANONICAL_ROOT and len(parts) > 1:
+        return ".".join(parts[:2])
+    return parts[0]

--- a/mcp_nixos/sources/nvf.py
+++ b/mcp_nixos/sources/nvf.py
@@ -7,17 +7,25 @@ NVF's standalone/flake interface publishes its option catalogue under
 canonical ``vim.*`` form before lookup or prefix browsing.
 
 The source tracks NVF's latest published unstable documentation and supports
-the existing ``search``, ``info``, ``browse``, and ``stats`` actions. Network
-loading and action implementations are added in later milestones.
+the existing ``search``, ``info``, ``browse``, and ``stats`` actions.
 """
 
 from typing import Final, TypedDict
+
+from ..caches import nvf_cache
+from ..config import APIError
+from ..utils import error
 
 NVF_SOURCE: Final = "nvf"
 NVF_DISPLAY_NAME: Final = "NVF"
 NVF_DOCS_TRACK: Final = "unstable"
 NVF_CANONICAL_ROOT: Final = "vim"
 NVF_SUPPORTED_ACTIONS: Final[frozenset[str]] = frozenset({"search", "info", "browse", "stats"})
+
+_NVF_SEARCH_DESCRIPTION_LIMIT: Final = 200
+_NVF_SEARCH_DEFAULT_LIMIT: Final = 120
+_NVF_INFO_EXAMPLE_LIMIT: Final = 500
+_NVF_BROWSE_LIMIT: Final = 100
 
 # Longest aliases come first to make the intended precedence explicit. Each
 # alias names the root itself (without a trailing dot), allowing both a full
@@ -77,3 +85,203 @@ def nvf_option_category(name: str) -> str:
     if parts[0].lower() == NVF_CANONICAL_ROOT and len(parts) > 1:
         return ".".join(parts[:2])
     return parts[0]
+
+
+def _compact_text(value: str, limit: int) -> str:
+    """Collapse whitespace and truncate text for compact result listings."""
+    compact = " ".join(value.split())
+    if len(compact) > limit:
+        return compact[:limit] + "..."
+    return compact
+
+
+def _nvf_match_score(option: NvfOption, query: str) -> int:
+    """Score a search match, prioritizing option paths over descriptions."""
+    name = option["name"].casefold()
+    description = option["description"].casefold()
+
+    if name == query:
+        return 100
+    if name.startswith(query + "."):
+        return 80
+    if query in name:
+        return 60
+    if query in description:
+        return 20
+    return 0
+
+
+def _search_nvf(query: str, limit: int) -> str:
+    """Search NVF options by canonical path or description text."""
+    try:
+        options = nvf_cache.get_options()
+        display_query = query.strip()
+        canonical_query = normalize_nvf_option_path(query).casefold()
+
+        matches: list[tuple[int, NvfOption]] = []
+        if canonical_query:
+            for option in options:
+                score = _nvf_match_score(option, canonical_query)
+                if score:
+                    matches.append((score, option))
+
+        matches.sort(key=lambda match: (-match[0], match[1]["name"].casefold()))
+        matches = matches[:limit]
+
+        if not matches:
+            return f"No NVF options found matching '{display_query}'"
+
+        results = [f"Found {len(matches)} NVF options matching '{display_query}':\n"]
+        for _score, option in matches:
+            results.append(f"* {option['name']}")
+            if option["type"]:
+                results.append(f"  Type: {option['type']}")
+            if option["default"]:
+                default = _compact_text(option["default"], _NVF_SEARCH_DEFAULT_LIMIT)
+                results.append(f"  Default: {default}")
+            if option["description"]:
+                description = _compact_text(option["description"], _NVF_SEARCH_DESCRIPTION_LIMIT)
+                results.append(f"  {description}")
+            results.append("")
+
+        return "\n".join(results).strip()
+    except APIError:
+        raise
+    except Exception as exc:
+        return error(str(exc))
+
+
+def _format_nvf_option(option: NvfOption) -> str:
+    """Format one normalized NVF option for detailed display."""
+    lines = [f"NVF Option: {option['name']}"]
+
+    if option["type"]:
+        lines.append(f"Type: {option['type']}")
+    if option["description"]:
+        lines.append(f"Description: {option['description']}")
+    if option["default"]:
+        lines.append(f"Default: {option['default']}")
+    if option["example"]:
+        example = option["example"]
+        if len(example) > _NVF_INFO_EXAMPLE_LIMIT:
+            example = example[:_NVF_INFO_EXAMPLE_LIMIT] + "..."
+        lines.append(f"Example: {example}")
+
+    declarations = option["declarations"]
+    if len(declarations) == 1:
+        lines.append(f"Declared in: {declarations[0]}")
+    elif declarations:
+        lines.append("Declared in:")
+        lines.extend(f"* {declaration}" for declaration in declarations)
+
+    if option["url"]:
+        lines.append(f"Documentation: {option['url']}")
+
+    return "\n".join(lines)
+
+
+def _info_nvf(name: str) -> str:
+    """Get detailed information for an exact NVF option path."""
+    try:
+        options = nvf_cache.get_options()
+        display_name = name.strip()
+        canonical_name = normalize_nvf_option_path(name)
+
+        for option in options:
+            if option["name"] == canonical_name:
+                return _format_nvf_option(option)
+
+        canonical_lower = canonical_name.casefold()
+        for option in options:
+            if option["name"].casefold() == canonical_lower:
+                return _format_nvf_option(option)
+
+        similar = sorted(
+            (option["name"] for option in options if canonical_lower in option["name"].casefold()),
+            key=str.casefold,
+        )[:5]
+        if similar:
+            return error(f"Option '{display_name}' not found. Similar: {', '.join(similar)}", "NOT_FOUND")
+        return error(f"NVF option '{display_name}' not found", "NOT_FOUND")
+    except APIError:
+        raise
+    except Exception as exc:
+        return error(str(exc))
+
+
+def _stats_nvf() -> str:
+    """Summarize the current published NVF option catalogue."""
+    try:
+        options = nvf_cache.get_options()
+        categories: dict[str, int] = {}
+        for option in options:
+            category = nvf_option_category(option["name"])
+            if category:
+                categories[category] = categories.get(category, 0) + 1
+
+        top_categories = sorted(categories.items(), key=lambda item: (-item[1], item[0].casefold()))[:10]
+        results = [
+            "NVF Statistics:",
+            f"* Documentation track: {NVF_DOCS_TRACK}",
+            f"* Total options: {len(options):,}",
+            f"* Categories: {len(categories)}",
+            "* Top categories:",
+        ]
+        for category, count in top_categories:
+            results.append(f"  - {category}: {count:,}")
+        return "\n".join(results)
+    except APIError:
+        raise
+    except Exception as exc:
+        return error(str(exc))
+
+
+def _browse_nvf_options(prefix: str) -> str:
+    """List NVF categories or options below a canonical/wrapped prefix."""
+    try:
+        options = nvf_cache.get_options()
+        canonical_prefix = normalize_nvf_option_path(prefix).rstrip(".")
+
+        if not canonical_prefix:
+            categories: dict[str, int] = {}
+            for option in options:
+                category = nvf_option_category(option["name"])
+                if category:
+                    categories[category] = categories.get(category, 0) + 1
+
+            sorted_categories = sorted(categories.items(), key=lambda item: (-item[1], item[0].casefold()))
+            results = [f"NVF option categories ({len(categories)} total):\n"]
+            for category, count in sorted_categories:
+                noun = "option" if count == 1 else "options"
+                results.append(f"* {category} ({count:,} {noun})")
+            return "\n".join(results)
+
+        prefix_lower = canonical_prefix.casefold()
+        prefix_dot = prefix_lower + "."
+        matches = [
+            option
+            for option in options
+            if option["name"].casefold() == prefix_lower or option["name"].casefold().startswith(prefix_dot)
+        ]
+
+        if not matches:
+            return f"No NVF options found with prefix '{canonical_prefix}'"
+
+        matches.sort(key=lambda option: option["name"].casefold())
+        results = [f"NVF options with prefix '{canonical_prefix}' ({len(matches):,} found):\n"]
+        for option in matches[:_NVF_BROWSE_LIMIT]:
+            results.append(f"* {option['name']}")
+            if option["type"]:
+                results.append(f"  Type: {option['type']}")
+            if option["description"]:
+                description = _compact_text(option["description"], _NVF_SEARCH_DESCRIPTION_LIMIT)
+                results.append(f"  {description}")
+            results.append("")
+
+        if len(matches) > _NVF_BROWSE_LIMIT:
+            results.append(f"... and {len(matches) - _NVF_BROWSE_LIMIT:,} more options")
+        return "\n".join(results).strip()
+    except APIError:
+        raise
+    except Exception as exc:
+        return error(str(exc))

--- a/mcp_nixos/utils.py
+++ b/mcp_nixos/utils.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 
 import requests
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from .config import DocumentParseError
 
@@ -27,12 +28,69 @@ def error(msg: str, code: str = "ERROR") -> str:
     return f"Error ({code}): {msg}"
 
 
-def parse_html_options(url: str, query: str = "", prefix: str = "", limit: int = 100) -> list[dict[str, str]]:
+def _option_matches(name: str, query: str, prefix: str) -> bool:
+    """Return whether an option name matches the requested filters."""
+    if query and query.lower() not in name.lower():
+        return False
+    return not prefix or name.startswith(prefix + ".") or name == prefix
+
+
+def _parse_home_manager_mdbook(soup: BeautifulSoup, query: str, prefix: str, limit: int | None) -> list[dict[str, str]]:
+    """Parse Home Manager options from the current mdBook HTML structure."""
+    options: list[dict[str, str]] = []
+
+    for heading in soup.select('h2[id^="opt-"]'):
+        anchor = heading.find("a", class_="header")
+        name = anchor.get_text(" ", strip=True) if isinstance(anchor, Tag) else heading.get_text(" ", strip=True)
+        if not name or not _option_matches(name, query, prefix):
+            continue
+
+        description_parts: list[str] = []
+        type_info = ""
+        metadata_started = False
+
+        for sibling in heading.next_siblings:
+            if not isinstance(sibling, Tag):
+                continue
+            if sibling.name in {"h1", "h2"}:
+                break
+            if sibling.name != "p":
+                continue
+
+            label = sibling.find("em")
+            label_text = label.get_text(" ", strip=True) if isinstance(label, Tag) else ""
+            if label_text == "Type:":
+                metadata_started = True
+                type_info = sibling.get_text(" ", strip=True).removeprefix("Type:").strip()
+            elif label_text in {"Default:", "Example:", "Declared by:"}:
+                metadata_started = True
+            elif not metadata_started:
+                description_parts.append(sibling.get_text(" ", strip=True))
+
+        description = " ".join(description_parts)
+        options.append(
+            {
+                "name": name,
+                "description": description[:200] if len(description) > 200 else description,
+                "type": type_info,
+            }
+        )
+        if limit is not None and len(options) >= limit:
+            break
+
+    return options
+
+
+def parse_html_options(url: str, query: str = "", prefix: str = "", limit: int | None = 100) -> list[dict[str, str]]:
     try:
         resp = requests.get(url, timeout=30)
         resp.raise_for_status()
         soup = BeautifulSoup(resp.content, "html.parser")
-        options = []
+
+        if "home-manager" in url and soup.select_one('h2[id^="opt-"]') is not None:
+            return _parse_home_manager_mdbook(soup, query, prefix, limit)
+
+        options: list[dict[str, str]] = []
         dts = soup.find_all("dt")
 
         for dt in dts:
@@ -55,9 +113,7 @@ def parse_html_options(url: str, query: str = "", prefix: str = "", limit: int =
 
             if "." not in name and len(name.split()) > 1:
                 continue
-            if query and query.lower() not in name.lower():
-                continue
-            if prefix and not (name.startswith(prefix + ".") or name == prefix):
+            if not _option_matches(name, query, prefix):
                 continue
 
             dd = dt.find_next_sibling("dd")
@@ -88,7 +144,7 @@ def parse_html_options(url: str, query: str = "", prefix: str = "", limit: int =
                         "type": type_info,
                     }
                 )
-                if len(options) >= limit:
+                if limit is not None and len(options) >= limit:
                     break
         return options
     except Exception as exc:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,17 @@ class TestNixSearchIntegration:
         assert_plain_text(result)
 
     @pytest.mark.asyncio
+    async def test_search_nvf_with_wrapped_option_path(self):
+        result = await nix_fn(
+            action="search",
+            query="programs.nvf.vim.languages.nix.enable",
+            source="nvf",
+            limit=3,
+        )
+        assert "vim.languages.nix.enable" in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
     async def test_search_flakehub(self):
         result = await nix_fn(action="search", query="nixpkgs", source="flakehub", limit=3)
         assert "flakehub" in result.lower() or "nixpkgs" in result.lower() or "No flakes" in result
@@ -107,6 +118,17 @@ class TestNixInfoIntegration:
     async def test_info_nixvim(self):
         result = await nix_fn(action="info", query="plugins.telescope.enable", source="nixvim")
         assert "Nixvim Option:" in result or "not found" in result or "NOT_FOUND" in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_info_nvf_with_module_wrapper(self):
+        result = await nix_fn(
+            action="info",
+            query="programs.nvf.settings.vim.languages.nix.enable",
+            source="nvf",
+        )
+        assert "NVF Option: vim.languages.nix.enable" in result
+        assert "Documentation: https://nvf.notashelf.dev/options.html#option-vim.languages.nix.enable" in result
         assert_plain_text(result)
 
     @pytest.mark.asyncio
@@ -201,6 +223,14 @@ class TestNixStatsIntegration:
         assert_plain_text(result)
 
     @pytest.mark.asyncio
+    async def test_stats_nvf(self):
+        result = await nix_fn(action="stats", source="nvf")
+        assert "NVF Statistics" in result
+        assert "Documentation track: unstable" in result
+        assert "Total options:" in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
     async def test_stats_flakehub(self):
         result = await nix_fn(action="stats", source="flakehub")
         assert "FlakeHub Statistics" in result
@@ -240,6 +270,24 @@ class TestNixOptionsIntegration:
     async def test_browse_nixvim_with_prefix(self):
         result = await nix_fn(action="options", source="nixvim", query="plugins")
         assert "plugins" in result.lower()
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_browse_nvf_categories(self):
+        result = await nix_fn(action="browse", source="nvf")
+        assert "NVF option categories" in result
+        assert "vim.languages" in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_browse_nvf_with_wrapped_prefix(self):
+        result = await nix_fn(
+            action="browse",
+            source="nvf",
+            query="programs.nvf.vim.languages.nix",
+        )
+        assert "NVF options with prefix 'vim.languages.nix'" in result
+        assert "vim.languages.nix.enable" in result
         assert_plain_text(result)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,7 +65,6 @@ class TestNixSearchIntegration:
         assert "telescope" in result.lower() or "No Nixvim" in result
         assert_plain_text(result)
 
-    @pytest.mark.asyncio
     async def test_search_nvf_with_wrapped_option_path(self):
         result = await nix_fn(
             action="search",
@@ -121,7 +120,6 @@ class TestNixInfoIntegration:
         assert "Nixvim Option:" in result or "not found" in result or "NOT_FOUND" in result
         assert_plain_text(result)
 
-    @pytest.mark.asyncio
     async def test_info_nvf_with_module_wrapper(self):
         result = await nix_fn(
             action="info",
@@ -223,7 +221,6 @@ class TestNixStatsIntegration:
         assert "Total options:" in result
         assert_plain_text(result)
 
-    @pytest.mark.asyncio
     async def test_stats_nvf(self):
         result = await nix_fn(action="stats", source="nvf")
         assert "NVF Statistics" in result
@@ -276,14 +273,12 @@ class TestNixOptionsIntegration:
         assert "plugins" in result.lower()
         assert_plain_text(result)
 
-    @pytest.mark.asyncio
     async def test_browse_nvf_categories(self):
         result = await nix_fn(action="browse", source="nvf")
         assert "NVF option categories" in result
         assert "vim.languages" in result
         assert_plain_text(result)
 
-    @pytest.mark.asyncio
     async def test_browse_nvf_with_wrapped_prefix(self):
         result = await nix_fn(
             action="browse",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,7 +44,8 @@ class TestNixSearchIntegration:
     @pytest.mark.asyncio
     async def test_search_home_manager(self):
         result = await nix_fn(action="search", query="git", source="home-manager", limit=3)
-        assert "git" in result.lower() or "No Home Manager" in result
+        assert "Found" in result
+        assert "git" in result.lower()
         assert_plain_text(result)
 
     @pytest.mark.asyncio
@@ -105,7 +106,7 @@ class TestNixInfoIntegration:
     @pytest.mark.asyncio
     async def test_info_home_manager(self):
         result = await nix_fn(action="info", query="programs.git.enable", source="home-manager")
-        assert "Option: programs.git.enable" in result or "not found" in result
+        assert "Option: programs.git.enable" in result
         assert_plain_text(result)
 
     @pytest.mark.asyncio
@@ -246,7 +247,8 @@ class TestNixOptionsIntegration:
     @pytest.mark.asyncio
     async def test_browse_home_manager(self):
         result = await nix_fn(action="options", source="home-manager")
-        assert "Home Manager" in result or "categories" in result.lower()
+        assert "Home Manager categories" in result
+        assert "programs" in result
         assert_plain_text(result)
 
     @pytest.mark.asyncio
@@ -258,6 +260,8 @@ class TestNixOptionsIntegration:
     @pytest.mark.asyncio
     async def test_browse_with_prefix(self):
         result = await nix_fn(action="options", source="home-manager", query="programs")
+        assert "Home Manager options with prefix 'programs'" in result
+        assert "programs." in result
         assert_plain_text(result)
 
     @pytest.mark.asyncio

--- a/tests/test_nvf.py
+++ b/tests/test_nvf.py
@@ -10,6 +10,12 @@ from mcp_nixos.sources.nvf import (
     NVF_DOCS_TRACK,
     NVF_SOURCE,
     NVF_SUPPORTED_ACTIONS,
+    NvfOption,
+    _browse_nvf_options,
+    _format_nvf_option,
+    _info_nvf,
+    _search_nvf,
+    _stats_nvf,
     normalize_nvf_option_path,
     nvf_option_category,
 )
@@ -69,6 +75,53 @@ def nvf_options_response(content: bytes | str = NVF_OPTIONS_HTML) -> Mock:
     response = Mock()
     response.content = content
     return response
+
+
+def nvf_option(
+    name: str,
+    *,
+    option_type: str = "boolean",
+    description: str = "",
+    default: str = "",
+    example: str = "",
+    declarations: list[str] | None = None,
+) -> NvfOption:
+    """Build a normalized NVF option record for source action tests."""
+    fragment = name.replace("<", "_").replace(">", "_")
+    return {
+        "name": name,
+        "type": option_type,
+        "description": description,
+        "default": default,
+        "example": example,
+        "declarations": declarations or [],
+        "url": f"{NVF_OPTIONS_URL}#option-{fragment}",
+    }
+
+
+NVF_SOURCE_OPTIONS = [
+    nvf_option(
+        "vim.languages.nix.enable",
+        description="Whether to enable Nix language support.",
+        default="false",
+        example="true",
+        declarations=["https://github.com/NotAShelf/nvf/blob/main/modules/plugins/languages/nix.nix"],
+    ),
+    nvf_option(
+        "vim.languages.nix.format.type",
+        option_type="string",
+        description="Select the Nix formatter.",
+        default='"alejandra"',
+    ),
+    nvf_option(
+        "vim.languages.lua.enable",
+        description="Whether to enable Lua language support.",
+        default="false",
+    ),
+    nvf_option("vim.lsp.enable", description="Whether to enable the LSP client.", default="false"),
+    nvf_option("vim.notes.enable", description="Enable a Nix-aware note-taking helper.", default="false"),
+    nvf_option("vim.theme.enable", description="Enable the configured color theme.", default="true"),
+]
 
 
 @pytest.mark.unit
@@ -214,3 +267,150 @@ class TestNvfCache:
 
         assert len(options) == 2
         assert get.call_count == 2
+
+
+@pytest.mark.unit
+class TestNvfSearch:
+    def test_search_ranks_option_paths_before_description_matches(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _search_nvf("nix", 10)
+
+        assert "Found 3 NVF options matching 'nix'" in result
+        assert result.index("vim.languages.nix.enable") < result.index("vim.languages.nix.format.type")
+        assert result.index("vim.languages.nix.format.type") < result.index("vim.notes.enable")
+        assert "Type: boolean" in result
+        assert "Default: false" in result
+        assert "Whether to enable Nix language support." in result
+
+    def test_search_normalizes_wrapped_option_path(self):
+        query = "programs.nvf.vim.languages.nix.enable"
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _search_nvf(query, 10)
+
+        assert f"Found 1 NVF options matching '{query}'" in result
+        assert "* vim.languages.nix.enable" in result
+
+    def test_search_applies_limit_after_deterministic_sorting(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _search_nvf("enable", 2)
+
+        assert "Found 2 NVF options" in result
+        assert "vim.languages.lua.enable" in result
+        assert "vim.languages.nix.enable" in result
+        assert "vim.lsp.enable" not in result
+
+    def test_search_reports_no_matches(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _search_nvf("does-not-exist", 10)
+
+        assert result == "No NVF options found matching 'does-not-exist'"
+
+    def test_search_propagates_cache_api_error(self):
+        with (
+            patch("mcp_nixos.sources.nvf.nvf_cache.get_options", side_effect=APIError("unavailable")),
+            pytest.raises(APIError, match="unavailable"),
+        ):
+            _search_nvf("nix", 10)
+
+
+@pytest.mark.unit
+class TestNvfInfo:
+    def test_info_normalizes_module_wrapper_and_formats_all_fields(self):
+        name = "programs.nvf.settings.vim.languages.nix.enable"
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _info_nvf(name)
+
+        assert "NVF Option: vim.languages.nix.enable" in result
+        assert "Type: boolean" in result
+        assert "Description: Whether to enable Nix language support." in result
+        assert "Default: false" in result
+        assert "Example: true" in result
+        assert "Declared in: https://github.com/NotAShelf/nvf/" in result
+        assert "Documentation: https://nvf.notashelf.dev/options.html#option-vim.languages.nix.enable" in result
+
+    def test_info_matches_canonical_name_case_insensitively(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _info_nvf("VIM.LANGUAGES.LUA.ENABLE")
+
+        assert result.startswith("NVF Option: vim.languages.lua.enable")
+
+    def test_info_suggests_options_below_a_non_exact_path(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _info_nvf("vim.languages.nix")
+
+        assert "Error (NOT_FOUND)" in result
+        assert "vim.languages.nix.enable" in result
+        assert "vim.languages.nix.format.type" in result
+
+    def test_info_reports_unknown_wrapper_only_option(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _info_nvf("programs.nvf.enable")
+
+        assert result == "Error (NOT_FOUND): NVF option 'programs.nvf.enable' not found"
+
+    def test_format_option_truncates_long_example_and_lists_declarations(self):
+        option = nvf_option(
+            "vim.test.option",
+            example="x" * 501,
+            declarations=["https://example.test/one.nix", "https://example.test/two.nix"],
+        )
+
+        result = _format_nvf_option(option)
+
+        assert f"Example: {'x' * 500}..." in result
+        assert "Declared in:\n* https://example.test/one.nix\n* https://example.test/two.nix" in result
+
+
+@pytest.mark.unit
+class TestNvfBrowse:
+    def test_browse_without_prefix_lists_two_component_categories(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _browse_nvf_options("")
+
+        assert "NVF option categories (4 total)" in result
+        assert "* vim.languages (3 options)" in result
+        assert "* vim.lsp (1 option)" in result
+        assert "* vim.notes (1 option)" in result
+        assert "* vim.theme (1 option)" in result
+        assert result.index("vim.lsp") < result.index("vim.notes") < result.index("vim.theme")
+
+    def test_browse_normalizes_wrapped_prefix_and_trailing_dot(self):
+        prefix = "PROGRAMS.NVF.SETTINGS.VIM.languages.nix."
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _browse_nvf_options(prefix)
+
+        assert "NVF options with prefix 'vim.languages.nix' (2 found)" in result
+        assert "vim.languages.nix.enable" in result
+        assert "vim.languages.nix.format.type" in result
+        assert "vim.languages.lua.enable" not in result
+
+    def test_browse_reports_unknown_canonical_prefix(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _browse_nvf_options("programs.nvf.vim.unknown")
+
+        assert result == "No NVF options found with prefix 'vim.unknown'"
+
+    def test_browse_caps_large_prefix_results(self):
+        options = [nvf_option(f"vim.plugins.example{i:03}.enable") for i in range(101)]
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=options):
+            result = _browse_nvf_options("vim.plugins")
+
+        assert "NVF options with prefix 'vim.plugins' (101 found)" in result
+        assert result.count("* vim.plugins.example") == 100
+        assert "vim.plugins.example099.enable" in result
+        assert "vim.plugins.example100.enable" not in result
+        assert "... and 1 more options" in result
+
+
+@pytest.mark.unit
+class TestNvfStats:
+    def test_stats_reports_track_totals_and_ranked_categories(self):
+        with patch("mcp_nixos.sources.nvf.nvf_cache.get_options", return_value=NVF_SOURCE_OPTIONS):
+            result = _stats_nvf()
+
+        assert "NVF Statistics:" in result
+        assert "Documentation track: unstable" in result
+        assert "Total options: 6" in result
+        assert "Categories: 4" in result
+        assert "vim.languages: 3" in result
+        assert result.index("vim.lsp: 1") < result.index("vim.notes: 1") < result.index("vim.theme: 1")

--- a/tests/test_nvf.py
+++ b/tests/test_nvf.py
@@ -1,0 +1,216 @@
+"""Unit tests for the NVF source contract and shared helpers."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from mcp_nixos.caches import NvfCache
+from mcp_nixos.config import KNOWN_SOURCES, NVF_OPTIONS_URL, APIError
+from mcp_nixos.sources.nvf import (
+    NVF_DOCS_TRACK,
+    NVF_SOURCE,
+    NVF_SUPPORTED_ACTIONS,
+    normalize_nvf_option_path,
+    nvf_option_category,
+)
+
+NVF_OPTIONS_HTML = """
+<html>
+  <body>
+    <div class="options-container">
+      <div class="option" id="option-_module.args">
+        <h3 class="option-name">
+          <a class="option-anchor" href="#option-_module.args">_module.args</a>
+        </h3>
+        <div class="option-type">Type: <code>attribute set</code></div>
+      </div>
+
+      <div class="option" id="option-vim.languages.nix.enable">
+        <h3 class="option-name">
+          <a class="option-anchor" href="#option-vim.languages.nix.enable">vim.languages.nix.enable</a>
+        </h3>
+        <div class="option-type">Type: <code>boolean</code></div>
+        <div class="option-description">
+          <p>Enable Nix language support.</p>
+          <p>Uses <code>nil</code> by default.</p>
+        </div>
+        <div class="option-default">Default: <code>false</code></div>
+        <div class="option-example">Example: <pre><code>{
+  enable = true;
+}</code></pre></div>
+        <div class="option-declared">
+          Declared in:
+          <a href="modules/languages/nix.nix">&lt;nvf/modules/languages/nix.nix&gt;</a>
+          <a href="https://github.com/NotAShelf/nvf/blob/main/modules/languages/default.nix">
+            &lt;nvf/modules/languages/default.nix&gt;
+          </a>
+        </div>
+      </div>
+
+      <div class="option" id="option-vim.theme.enable">
+        <h3 class="option-name">
+          <a class="option-anchor">vim.theme.enable</a>
+        </h3>
+        <div class="option-type">Type: <code>boolean</code></div>
+        <div class="option-description"><p>Enable the configured theme.</p></div>
+      </div>
+
+      <div class="option" id="option-vim.malformed">
+        <div class="option-description">Missing its name anchor.</div>
+      </div>
+    </div>
+  </body>
+</html>
+"""
+
+
+def nvf_options_response(content: bytes | str = NVF_OPTIONS_HTML) -> Mock:
+    """Build a successful response mock containing an NVF options document."""
+    response = Mock()
+    response.content = content
+    return response
+
+
+@pytest.mark.unit
+class TestNvfSourceContract:
+    def test_source_name_and_actions(self):
+        assert NVF_SOURCE == "nvf"
+        assert NVF_SUPPORTED_ACTIONS == {"search", "info", "browse", "stats"}
+        assert NVF_DOCS_TRACK == "unstable"
+
+    def test_source_is_reserved_and_uses_published_options(self):
+        assert "nvf" in KNOWN_SOURCES
+        assert NVF_OPTIONS_URL == "https://nvf.notashelf.dev/options.html"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("vim.languages.nix.enable", "vim.languages.nix.enable"),
+        ("programs.nvf.vim.languages.nix.enable", "vim.languages.nix.enable"),
+        ("programs.nvf.settings.vim.languages.nix.enable", "vim.languages.nix.enable"),
+        ("config.programs.nvf.settings.vim.languages.nix.enable", "vim.languages.nix.enable"),
+        ("programs.nvf.vim", "vim"),
+        (" PROGRAMS.NVF.SETTINGS.VIM.languages.nix.enable ", "vim.languages.nix.enable"),
+        ("nix diagnostics", "nix diagnostics"),
+        ("programs.nvf.enable", "programs.nvf.enable"),
+        ("", ""),
+    ],
+)
+def test_normalize_nvf_option_path(given: str, expected: str):
+    assert normalize_nvf_option_path(given) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("vim.languages.nix.enable", "vim.languages"),
+        ("programs.nvf.vim.lsp.enable", "vim.lsp"),
+        ("programs.nvf.settings.vim.treesitter.enable", "vim.treesitter"),
+        ("vim", "vim"),
+        ("_module.args", "_module"),
+        ("", ""),
+    ],
+)
+def test_nvf_option_category(name: str, expected: str):
+    assert nvf_option_category(name) == expected
+
+
+@pytest.mark.unit
+class TestNvfCache:
+    def test_parse_options_normalizes_complete_and_optional_fields(self):
+        options = NvfCache._parse_options(NVF_OPTIONS_HTML)
+
+        assert [option["name"] for option in options] == ["vim.languages.nix.enable", "vim.theme.enable"]
+        assert options[0] == {
+            "name": "vim.languages.nix.enable",
+            "type": "boolean",
+            "description": "Enable Nix language support. Uses nil by default.",
+            "default": "false",
+            "example": "{\n  enable = true;\n}",
+            "declarations": [
+                "https://nvf.notashelf.dev/modules/languages/nix.nix",
+                "https://github.com/NotAShelf/nvf/blob/main/modules/languages/default.nix",
+            ],
+            "url": "https://nvf.notashelf.dev/options.html#option-vim.languages.nix.enable",
+        }
+        assert options[1] == {
+            "name": "vim.theme.enable",
+            "type": "boolean",
+            "description": "Enable the configured theme.",
+            "default": "",
+            "example": "",
+            "declarations": [],
+            "url": "https://nvf.notashelf.dev/options.html#option-vim.theme.enable",
+        }
+
+    def test_get_options_fetches_once_and_reuses_process_cache(self):
+        response = nvf_options_response(NVF_OPTIONS_HTML.encode())
+        cache = NvfCache()
+
+        with patch("mcp_nixos.caches.requests.get", return_value=response) as get:
+            first = cache.get_options()
+            second = cache.get_options()
+
+        assert first is second
+        assert len(first) == 2
+        get.assert_called_once_with(NVF_OPTIONS_URL, timeout=30)
+        response.raise_for_status.assert_called_once_with()
+
+    def test_get_options_reports_timeout(self):
+        cache = NvfCache()
+
+        with (
+            patch("mcp_nixos.caches.requests.get", side_effect=requests.Timeout),
+            pytest.raises(APIError, match="Timeout fetching NVF options"),
+        ):
+            cache.get_options()
+
+    def test_get_options_reports_http_failure(self):
+        response = nvf_options_response()
+        response.raise_for_status.side_effect = requests.HTTPError("503 Server Error")
+        cache = NvfCache()
+
+        with (
+            patch("mcp_nixos.caches.requests.get", return_value=response),
+            pytest.raises(APIError, match="Failed to fetch NVF options: 503 Server Error"),
+        ):
+            cache.get_options()
+
+    def test_get_options_rejects_document_without_canonical_options(self):
+        response = nvf_options_response(b"<html><body>No option cards</body></html>")
+        cache = NvfCache()
+
+        with (
+            patch("mcp_nixos.caches.requests.get", return_value=response),
+            pytest.raises(APIError, match=r"no canonical vim\.\* options found"),
+        ):
+            cache.get_options()
+
+        assert cache.options is None
+
+    def test_get_options_wraps_unexpected_parser_failure(self):
+        response = nvf_options_response()
+        cache = NvfCache()
+
+        with (
+            patch("mcp_nixos.caches.requests.get", return_value=response),
+            patch.object(cache, "_parse_options", side_effect=ValueError("bad document")),
+            pytest.raises(APIError, match="Failed to parse NVF options: bad document"),
+        ):
+            cache.get_options()
+
+    def test_failed_document_is_not_cached(self):
+        bad_response = nvf_options_response(b"<html></html>")
+        good_response = nvf_options_response()
+        cache = NvfCache()
+
+        with patch("mcp_nixos.caches.requests.get", side_effect=[bad_response, good_response]) as get:
+            with pytest.raises(APIError, match=r"no canonical vim\.\* options found"):
+                cache.get_options()
+            options = cache.get_options()
+
+        assert len(options) == 2
+        assert get.call_count == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -134,6 +134,72 @@ class TestParseHtmlOptions:
         assert len(result) >= 1
 
     @patch("mcp_nixos.utils.requests.get")
+    def test_home_manager_mdbook_format(self, mock_get):
+        html = b"""
+        <html><body>
+        <h2 id="opt-programs.git.enable">
+          <a class="header" href="#opt-programs.git.enable">programs.git.enable</a>
+        </h2>
+        <p>Whether to enable Git.</p>
+        <p><em>Type:</em> boolean</p>
+        <p><em>Default:</em></p>
+        <pre><code>false</code></pre>
+        <p><em>Declared by:</em></p>
+        <ul><li>modules/programs/git.nix</li></ul>
+        <h2 id="opt-accounts.email.accounts._name_.primary">
+          <a class="header" href="#opt-accounts.email.accounts._name_.primary">
+            accounts.email.accounts.&lt;name&gt;.primary
+          </a>
+        </h2>
+        <p>Whether this is the primary account.</p>
+        <p><em>Type:</em> boolean</p>
+        <h2 id="nixos-opt-services.test.enable">
+          <a class="header">services.test.enable</a>
+        </h2>
+        <p>This belongs to the NixOS option catalogue.</p>
+        <p><em>Type:</em> boolean</p>
+        </body></html>
+        """
+        mock_resp = Mock()
+        mock_resp.content = html
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+
+        result = parse_html_options(HOME_MANAGER_URL, limit=None)
+
+        assert result == [
+            {
+                "name": "programs.git.enable",
+                "description": "Whether to enable Git.",
+                "type": "boolean",
+            },
+            {
+                "name": "accounts.email.accounts.<name>.primary",
+                "description": "Whether this is the primary account.",
+                "type": "boolean",
+            },
+        ]
+
+    @patch("mcp_nixos.utils.requests.get")
+    def test_home_manager_mdbook_query_and_prefix(self, mock_get):
+        html = b"""
+        <html><body>
+        <h2 id="opt-programs.git.enable"><a class="header">programs.git.enable</a></h2>
+        <p>Whether to enable Git.</p><p><em>Type:</em> boolean</p>
+        <h2 id="opt-services.syncthing.enable"><a class="header">services.syncthing.enable</a></h2>
+        <p>Whether to enable Syncthing.</p><p><em>Type:</em> boolean</p>
+        </body></html>
+        """
+        mock_resp = Mock()
+        mock_resp.content = html
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+
+        result = parse_html_options(HOME_MANAGER_URL, query="git", prefix="programs")
+
+        assert [option["name"] for option in result] == ["programs.git.enable"]
+
+    @patch("mcp_nixos.utils.requests.get")
     def test_timeout(self, mock_get):
         from mcp_nixos.server import DocumentParseError
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -87,11 +87,11 @@ class TestNixToolValidation:
         assert '"type": "options"' in result
 
     @pytest.mark.asyncio
-    async def test_browse_only_for_hm_darwin_nixvim_noogle(self):
+    async def test_browse_error_lists_every_supported_option_source(self):
         result = await nix_fn(action="browse", source="flakes")
         assert "Error" in result
         assert "home-manager" in result and "darwin" in result
-        assert "nixvim" in result and "noogle" in result
+        assert "nixvim" in result and "nvf" in result and "noogle" in result
 
     @pytest.mark.asyncio
     async def test_limit_too_low(self):
@@ -737,6 +737,7 @@ class TestServerInstructions:
         instructions = getattr(mcp, "instructions", "") or ""
         assert "nixpkgs" in instructions.lower()
         assert "nix_versions" in instructions
+        assert "NVF" in instructions
 
     def test_server_instructions_use_json_call_shapes(self):
         """Recipe examples must match the JSON-object shape models actually send."""
@@ -748,6 +749,7 @@ class TestServerInstructions:
         # does not work over MCP.
         assert '{"action":"info","query":"X","channel":"Y"}' in instructions
         assert '{"action":"channels"}' in instructions
+        assert '{"action":"search","source":"nvf","query":"X"}' in instructions
         assert "action=" not in instructions.replace('"action":', "")
 
 
@@ -985,6 +987,63 @@ class TestNixvimOptions:
         result = await nix_fn(action="options", source="nixvim", query="plugins")
         assert result == "Nixvim options with prefix 'plugins'"
         mock_browse.assert_called_once_with("plugins")
+
+
+@pytest.mark.unit
+class TestNvfRouting:
+    """Test every unified nix action routed to the NVF source."""
+
+    @patch("mcp_nixos.server._search_nvf")
+    @pytest.mark.asyncio
+    async def test_search_nvf_forwards_query_and_limit(self, mock_search):
+        mock_search.return_value = "Found NVF options"
+
+        result = await nix_fn(action="search", query="languages.nix", source="nvf", limit=7)
+
+        assert result == "Found NVF options"
+        mock_search.assert_called_once_with("languages.nix", 7)
+
+    @patch("mcp_nixos.server._info_nvf")
+    @pytest.mark.asyncio
+    async def test_info_nvf_forwards_wrapped_option_path(self, mock_info):
+        name = "programs.nvf.vim.languages.nix.enable"
+        mock_info.return_value = "NVF Option: vim.languages.nix.enable"
+
+        result = await nix_fn(action="info", query=name, source="nvf")
+
+        assert result == "NVF Option: vim.languages.nix.enable"
+        mock_info.assert_called_once_with(name)
+
+    @patch("mcp_nixos.server._stats_nvf")
+    @pytest.mark.asyncio
+    async def test_stats_nvf(self, mock_stats):
+        mock_stats.return_value = "NVF Statistics:\n* Total options: 2,494"
+
+        result = await nix_fn(action="stats", source="nvf")
+
+        assert result == "NVF Statistics:\n* Total options: 2,494"
+        mock_stats.assert_called_once_with()
+
+    @patch("mcp_nixos.server._browse_nvf_options")
+    @pytest.mark.asyncio
+    async def test_browse_nvf_forwards_wrapped_prefix(self, mock_browse):
+        prefix = "programs.nvf.settings.vim.languages.nix"
+        mock_browse.return_value = "NVF options with prefix 'vim.languages.nix'"
+
+        result = await nix_fn(action="browse", query=prefix, source="nvf")
+
+        assert result == "NVF options with prefix 'vim.languages.nix'"
+        mock_browse.assert_called_once_with(prefix)
+
+    @patch("mcp_nixos.server._browse_nvf_options")
+    @pytest.mark.asyncio
+    async def test_legacy_options_action_routes_to_nvf_browse(self, mock_browse):
+        mock_browse.return_value = "NVF option categories"
+
+        result = await nix_fn(action="options", source="nvf")
+
+        assert result == "NVF option categories"
+        mock_browse.assert_called_once_with("")
 
 
 @pytest.mark.unit

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -994,7 +994,6 @@ class TestNvfRouting:
     """Test every unified nix action routed to the NVF source."""
 
     @patch("mcp_nixos.server._search_nvf")
-    @pytest.mark.asyncio
     async def test_search_nvf_forwards_query_and_limit(self, mock_search):
         mock_search.return_value = "Found NVF options"
 
@@ -1004,7 +1003,6 @@ class TestNvfRouting:
         mock_search.assert_called_once_with("languages.nix", 7)
 
     @patch("mcp_nixos.server._info_nvf")
-    @pytest.mark.asyncio
     async def test_info_nvf_forwards_wrapped_option_path(self, mock_info):
         name = "programs.nvf.vim.languages.nix.enable"
         mock_info.return_value = "NVF Option: vim.languages.nix.enable"
@@ -1015,7 +1013,6 @@ class TestNvfRouting:
         mock_info.assert_called_once_with(name)
 
     @patch("mcp_nixos.server._stats_nvf")
-    @pytest.mark.asyncio
     async def test_stats_nvf(self, mock_stats):
         mock_stats.return_value = "NVF Statistics:\n* Total options: 2,494"
 
@@ -1025,7 +1022,6 @@ class TestNvfRouting:
         mock_stats.assert_called_once_with()
 
     @patch("mcp_nixos.server._browse_nvf_options")
-    @pytest.mark.asyncio
     async def test_browse_nvf_forwards_wrapped_prefix(self, mock_browse):
         prefix = "programs.nvf.settings.vim.languages.nix"
         mock_browse.return_value = "NVF options with prefix 'vim.languages.nix'"
@@ -1036,7 +1032,6 @@ class TestNvfRouting:
         mock_browse.assert_called_once_with(prefix)
 
     @patch("mcp_nixos.server._browse_nvf_options")
-    @pytest.mark.asyncio
     async def test_legacy_options_action_routes_to_nvf_browse(self, mock_browse):
         mock_browse.return_value = "NVF option categories"
 

--- a/website/about.md
+++ b/website/about.md
@@ -19,6 +19,7 @@ It provides real-time access to:
 - **Home Manager** settings for user-level configuration
 - **nix-darwin** macOS configuration options
 - **Nixvim** options via NuschtOS search
+- **NVF** options via its published unstable documentation
 - **FlakeHub** and community flake registries
 - **Nix function signatures** and documentation via Noogle
 - **NixOS Wiki** and **nix.dev** for community + official guides
@@ -41,14 +42,15 @@ and utilities for developers and systems engineers.
 MCP-NixOS v2.x is a **stateless, async FastMCP 3.x server** with a modular structure
 (Python 3.11+). No persistent caches, no databases, no sacred goat to appease — live
 APIs are the source of truth, with some in-process caching for discovered channels
-and index-style sources (Nixvim, Noogle, nix.dev) so a single server run doesn't
+and index-style sources (Nixvim, NVF, Noogle, nix.dev) so a single server run doesn't
 re-fetch the same catalog on every query.
 
 - **`nix` tool** — Unified query router for search / info / stats / browse / channels /
   flake-inputs / cache / store across every source.
 - **`nix_versions` tool** — Package version history via NixHub.io.
 - **Elasticsearch client** — Queries search.nixos.org for packages, options, and flakes.
-- **HTML parsers** — Parse Home Manager and nix-darwin documentation on demand.
+- **HTML parsers** — Parse Home Manager and nix-darwin documentation on demand and
+  normalize NVF's published option catalogue into plain-text records.
 - **Plain-text formatter** — All responses are rendered as human-readable text for
   optimal LLM consumption. No XML. No JSON leaking into prompts.
 - **Async everywhere** — Every blocking HTTP or file I/O call is wrapped in
@@ -68,6 +70,8 @@ backend is a small, bounded change.
 - **FlakeHub integration** — Search and discover flakes from the FlakeHub registry.
 - **Noogle integration** — 2K+ Nix functions with type signatures via noogle.dev.
 - **Nixvim integration** — 5K+ Neovim configuration options via NuschtOS search.
+- **NVF integration** — 2.4K+ Neovim configuration options from the latest published
+  unstable documentation, with `vim.*` and module-wrapper path support.
 - **Wiki & nix.dev** — Community articles and official tutorials, searchable in one
   place.
 - **Version history** — Package version tracking with nixpkgs commit hashes via
@@ -76,8 +80,8 @@ backend is a small, bounded change.
   download sizes, compression, and per-platform availability.
 - **Local flake inputs** — Read your pinned dependencies straight out of `/nix/store`,
   with security checks to keep paths inside the store.
-- **Stateless design** — Direct API calls, no caching complexity. Simple, reliable,
-  maintainable.
+- **No persistent state** — Direct API calls plus bounded in-process catalogue caches;
+  no database or on-disk index to maintain.
 
 ## What is Model Context Protocol? {#what-is-model-context-protocol}
 
@@ -173,6 +177,8 @@ checking, and tests.
 - [NuschtOS](https://github.com/NuschtOS/search) — Static option search infrastructure
 - [Nixvim](https://github.com/nix-community/nixvim) — Neovim configuration framework
   for Nix
+- [NVF](https://github.com/NotAShelf/nvf) — Neovim configuration framework and
+  [published option catalogue](https://nvf.notashelf.dev/options.html)
 
 ---
 

--- a/website/index.md
+++ b/website/index.md
@@ -36,8 +36,8 @@ features:
     title: Flakes & FlakeHub
     details: Search community flakes on search.nixos.org and the FlakeHub registry by Determinate Systems.
   - icon: 🧠
-    title: Noogle + Nixvim
-    details: 2K+ Nix functions with type signatures plus 5K+ Nixvim options. Because writing Nix is already hard enough.
+    title: Noogle + Neovim Modules
+    details: 2K+ Nix functions with type signatures, 5K+ Nixvim options, and 2.4K+ NVF options. Because writing Nix is already hard enough.
   - icon: ⏱️
     title: Package Version History
     details: Historical versions with nixpkgs commit hashes via NixHub.io. Find that one Ruby version from 2019 you're pretending to still support.
@@ -104,6 +104,7 @@ All responses come back as **plain text**, because your LLM does not want to par
 - **[FlakeHub](https://flakehub.com)** — Determinate Systems flake registry
 - **[noogle.dev](https://noogle.dev)** — Nix function signatures
 - **[NuschtOS](https://github.com/NuschtOS/search)** — Nixvim option index
+- **[NVF docs](https://nvf.notashelf.dev/options.html)** — Published NVF option catalogue
 - **[wiki.nixos.org](https://wiki.nixos.org)** — Community wiki
 - **[nix.dev](https://nix.dev)** — Official tutorials & guides
 - **Local `/nix/store`** — Your pinned flake inputs, read directly

--- a/website/usage.md
+++ b/website/usage.md
@@ -191,7 +191,7 @@ nix(action, query, source, type, channel, limit, version, system)
 | `search` | Search packages, options, programs, flakes, wiki, docs |
 | `info` | Get detailed info about a package, option, or function |
 | `stats` | Counts, channels, categories |
-| `browse` | Browse Home Manager / Darwin options by prefix (alias: `options`) |
+| `browse` | Browse Home Manager, Darwin, Nixvim, NVF, or Noogle by prefix (alias: `options`) |
 | `channels` | List available NixOS channels |
 | `flake-inputs` | Explore local flake inputs from the Nix store |
 | `cache` | Check binary cache status for packages |
@@ -205,10 +205,15 @@ nix(action, query, source, type, channel, limit, version, system)
 | `flakes` | Community flakes (search.nixos.org) |
 | `flakehub` | FlakeHub registry (flakehub.com) |
 | `nixvim` | Nixvim Neovim configuration options |
+| `nvf` | NVF Neovim configuration options (latest unstable docs) |
 | `noogle` | Nix function signatures & docs (noogle.dev) |
 | `wiki` | NixOS Wiki articles (wiki.nixos.org) |
 | `nix-dev` | Official Nix docs (nix.dev) |
 | `nixhub` | Package metadata & store paths (nixhub.io) |
+
+NVF returns canonical `vim.*` option paths. It also accepts the shorthand
+`programs.nvf.vim.*` and the actual NixOS/Home Manager module path
+`programs.nvf.settings.vim.*` as input aliases.
 
 #### Examples
 
@@ -227,6 +232,15 @@ nix(action="browse", source="darwin", query="system.defaults")
 
 # Search Nixvim options
 nix(action="search", query="telescope", source="nixvim")
+
+# Search NVF options
+nix(action="search", query="vim.languages.nix", source="nvf")
+
+# Inspect an NVF option through its Home Manager/NixOS wrapper path
+nix(action="info", query="programs.nvf.settings.vim.languages.nix.enable", source="nvf")
+
+# Browse an NVF prefix (the shorter wrapper alias is accepted too)
+nix(action="browse", query="programs.nvf.vim.languages.nix", source="nvf")
 
 # Search FlakeHub
 nix(action="search", query="nixpkgs", source="flakehub")


### PR DESCRIPTION
## What changed

This PR adds [NVF](https://github.com/NotAShelf/nvf) as a source for the existing `nix` tool. It supports `search`, `info`, `browse`, and `stats` using NVF's published unstable option documentation.

The source validates the parsed options before keeping them in the process cache. Results include the option type, description, default, example, declarations, and a link back to the documentation. The MCP instructions, Pi extension, README, and website now include the NVF source, and the new behavior is covered by unit, router, and live integration tests.

NVF publishes its options as `vim.*`, for example `vim.languages.nix.enable`. The same option can be queried through its NixOS or Home Manager wrapper path:

- `programs.nvf.vim.*`
- `programs.nvf.settings.vim.*`
- `config.programs.nvf.settings.vim.*`

The wrapper is stripped before the lookup, so results always use the `vim.*` form. `browse` is the preferred action for walking the option tree, while `options` remains available as a compatibility alias.

### Local test

<img width="850" height="776" alt="image" src="https://github.com/user-attachments/assets/db9882cd-1e5f-43e5-96d2-e613e313470d" />

## Checks run

- `nix develop --command run-tests`: 398 passed, 1 skipped
- `ruff check mcp_nixos tests`
- `ruff format --check mcp_nixos tests`
- `mypy mcp_nixos`
- `nix flake check`
- `nix build`

I also used the fork from a separate project and confirmed that NVF search works through an MCP client.

## Extra commits included

`f24af0d feat(git): ignore zed editor project config`

This adds `.zed/` to `.gitignore` so local Zed settings stay out of the repository.

`f1575e6 fix(home-manager): parse mdbook option docs`

Home Manager's old `options.xhtml` URL now serves a client-side redirect to its new mdBook documentation. Since `requests` does not execute that redirect, MCP-NixOS was parsing an empty document and returning no Home Manager options.

This commit reads the complete mdBook print view and parses its `h2[id^="opt-"]` option sections. Search, info, browse, and stats work again. The parser keeps `<name>` placeholders, skips the NixOS and nix-darwin sections in the combined document, and no longer stops at 5,000 options. The integration tests now require real Home Manager results instead of accepting an empty catalogue.

This fixes #172 independently of draft PR #174, which takes a different approach to loading the same documentation.

Closes #188
Closes #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added **NVF** as a supported source for search, info, browse, and option statistics.
  * Added support for canonical `vim.*` paths plus accepted NVF shorthand/wrapper aliases.
  * Updated browsing to use the `browse` action (including NVF), replacing the legacy browsing alias in examples/help text.

* **Documentation**
  * Expanded README, website, and tool guidance to cover NVF behavior and examples.

* **Bug Fixes**
  * Improved Home Manager option parsing and broadened Home Manager statistics coverage.

* **Tests**
  * Added and tightened integration and unit tests for NVF and Home Manager.

* **Chores**
  * Updated ignore rules for the local `.zed/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->