### PR TITLE
fix(website): prevent mobile overlap and refresh errors

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -50,4 +50,27 @@ jobs:
     - name: Deploy to S3
       run: |
         aws s3 sync website/out/ s3://urandom-mcp-nixos/ --delete
-        aws cloudfront create-invalidation --distribution-id E1QS1G7FYYJ6TL --paths "/*"
+
+        # VitePress clean URLs link to /about while S3 stores about.html.
+        # Publish extensionless aliases so direct visits and refreshes work.
+        find website/out -type f -name '*.html' ! -name 'index.html' -print0 |
+          while IFS= read -r -d '' page; do
+            route="${page#website/out/}"
+            aws s3 cp "$page" "s3://urandom-mcp-nixos/${route%.html}" \
+              --content-type 'text/html; charset=utf-8'
+          done
+
+        invalidation_id=$(aws cloudfront create-invalidation \
+          --distribution-id E1QS1G7FYYJ6TL \
+          --paths '/*' \
+          --query 'Invalidation.Id' \
+          --output text)
+        aws cloudfront wait invalidation-completed \
+          --distribution-id E1QS1G7FYYJ6TL \
+          --id "$invalidation_id"
+
+    - name: Verify deployed clean URLs
+      run: |
+        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/ > /dev/null
+        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/about > /dev/null
+        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/usage > /dev/null

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -58,6 +58,14 @@
   --vp-button-brand-hover-border: var(--nix-secondary);
 }
 
+/* Keep the home artwork below the fixed navigation on stacked layouts. */
+@media (max-width: 959px) {
+  .VPHero .image {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
 /* Smooth anchor jumps for deep links — gated on reduced-motion preference */
 @media (prefers-reduced-motion: no-preference) {
   html {


### PR DESCRIPTION
## Summary
- keep the home hero artwork below the fixed navigation on mobile and tablet layouts
- publish extensionless S3 objects for VitePress clean URLs so direct visits and refreshes do not return AccessDenied
- wait for CloudFront invalidation and verify the home, About, and Usage routes after deployment

## Validation
- `npm run check`
- `npm run build`
- production preview at 390x844 in light and dark modes
- desktop smoke check at 1440x900
- mobile Home -> What is this? -> About -> refresh remains rendered with HTTP 200
- `git diff --check` and pre-commit YAML validation