### PR TITLE
fix(ci): retry website verification errors

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -71,6 +71,6 @@ jobs:
 
     - name: Verify deployed clean URLs
       run: |
-        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/ > /dev/null
-        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/about > /dev/null
-        curl --fail --silent --show-error --retry 5 --retry-delay 3 https://mcp-nixos.io/usage > /dev/null
+        curl --fail --silent --show-error --location --retry 5 --retry-delay 3 --retry-all-errors https://mcp-nixos.io/ > /dev/null
+        curl --fail --silent --show-error --location --retry 5 --retry-delay 3 --retry-all-errors https://mcp-nixos.io/about > /dev/null
+        curl --fail --silent --show-error --location --retry 5 --retry-delay 3 --retry-all-errors https://mcp-nixos.io/usage > /dev/null


### PR DESCRIPTION
## Summary
- follow up on Copilot review feedback from #193
- make deployment verification retry HTTP failures, including transient 403 responses
- follow redirects during live route checks

## Validation
- pre-commit YAML validation
- `git diff --check`