### PR TITLE
fix(search): align ES query semantics with search.nixos.org frontend

### DIFF
--- a/mcp_nixos/sources/nixos.py
+++ b/mcp_nixos/sources/nixos.py
@@ -7,6 +7,106 @@ from typing import Any
 from ..utils import error
 from .base import es_query, get_channel_suggestions, get_channels
 
+# Field weights mirror the search.nixos.org frontend Elm source
+# (nixos-search repo: frontend/src/Page/Packages.elm — defaultSearchFields).
+# Verified against live ES index document keys — only fields that actually exist
+# on the NixOS packages / options indices are referenced.
+# Note: the frontend options query template also references option_name_query,
+# service_package(s), flake_name — those are template fields for the
+# home-manager / darwin / flakes indices and are silently ignored by ES against
+# the NixOS options index, so we omit them here.
+_PACKAGE_SEARCH_FIELDS = [
+    "package_attr_name^9",
+    "package_programs^9",
+    "package_pname^6",
+    "package_description^1.3",
+    "package_longDescription^1",
+]
+_OPTION_SEARCH_FIELDS = [
+    "option_name^6",
+    "option_description^1",
+]
+
+# Query length cap: wildcard is a term-level scan, so an overlong query makes
+# substring matching noticeably slower. 200 chars covers any realistic package
+# name or option path (longest observed nixpkgs attr paths are well under 100)
+# while blocking LLM-generated paragraphs.
+_MAX_QUERY_LEN = 200
+
+
+def _hyphen_variants(token: str) -> set[str]:
+    """Return the token plus its `_ ↔ -` swap variants.
+
+    The nix ecosystem mixes `_` and `-` (e.g. `steam_install` / `steam-runtime`),
+    so search should treat them as interchangeable.
+    """
+    return {token, token.replace("_", "-"), token.replace("-", "_")}
+
+
+def _wildcard_clauses(query: str, field: str) -> list[dict[str, Any]]:
+    """Build case_insensitive wildcard clauses, mirroring the frontend Elm (Search.elm).
+
+    1. The whole query string is a candidate (covers substring matches like
+       `musicfree` hitting `musicfree-desktop`).
+    2. Each whitespace-separated token gets its own wildcard clause (multi-word queries).
+    3. `_ ↔ -` swap variants via `_hyphen_variants`.
+
+    Precondition: `query` must already be normalized (trimmed) by the caller —
+    `_search_nixos` calls `_normalize_query` before reaching here, which turns
+    pure-whitespace input into an empty string. An empty `query` yields zero
+    clauses, leaving the dis_max branch inactive.
+    """
+    lowered = query.lower()
+    tokens = [lowered, *lowered.split()]
+    candidates: set[str] = set()
+    for token in tokens:
+        candidates |= _hyphen_variants(token)
+    candidates.discard("")
+    return [{"wildcard": {field: {"value": f"*{w}*", "case_insensitive": True}}} for w in sorted(candidates)]
+
+
+def _normalize_query(query: str) -> str:
+    """Centralized input preprocessing at the `_search_nixos` entry: trim, truncate, escape.
+
+    Escapes `*`, `?`, `\\` so they are treated as literals by ES wildcard semantics
+    (prevents metacharacter injection). Length cap blocks LLM-generated paragraphs
+    that would make wildcard substring scans expensive.
+    """
+    q = query.strip()
+    if len(q) > _MAX_QUERY_LEN:
+        q = q[:_MAX_QUERY_LEN]
+    return q.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
+
+
+def _build_search_query(query: str, fields: list[str], wildcard_field: str) -> dict[str, Any]:
+    """Build the ES query body mirroring the search.nixos.org frontend semantics.
+
+    `dis_max(multi_match + wildcard fallback)`:
+    - `multi_match(cross_fields, whitespace analyzer, operator=and)` does the
+      weighted cross-field match (tie_breaker / auto_generate_synonyms_phrase_query
+      values come straight from the frontend Elm source).
+    - The wildcard fallback (tokenized + `_ ↔ -` swapped + case_insensitive)
+      covers substring and hyphen-variant matches the analyzer would otherwise miss.
+    """
+    return {
+        "dis_max": {
+            "tie_breaker": 0.7,
+            "queries": [
+                {
+                    "multi_match": {
+                        "type": "cross_fields",
+                        "query": query,
+                        "analyzer": "whitespace",
+                        "auto_generate_synonyms_phrase_query": False,
+                        "operator": "and",
+                        "fields": fields,
+                    }
+                },
+                *_wildcard_clauses(query, wildcard_field),
+            ],
+        }
+    }
+
 
 def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str:
     """Search NixOS packages, options, or programs via Elasticsearch."""
@@ -21,44 +121,20 @@ def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str
     if channel not in channels:
         return error(f"Invalid channel '{channel}'. {get_channel_suggestions(channel)}")
 
+    # Centralized preprocessing: trim + length truncation + wildcard metachar escaping
+    # (SSOT — downstream helpers assume normalized input).
+    query = _normalize_query(query)
+
     try:
-        if search_type == "packages":
-            # For dotted names like "kdePackages.qt6ct", extract the last component
-            # as the pname and also search the full string against package_attr_name
-            pname_query = query.rsplit(".", 1)[-1] if "." in query else query
-            q = {
-                "bool": {
-                    "must": [{"term": {"type": "package"}}],
-                    "should": [
-                        {"match": {"package_pname": {"query": pname_query, "boost": 3}}},
-                        {"match": {"package_attr_name": {"query": query, "boost": 2}}},
-                        {"match": {"package_description": pname_query}},
-                    ],
-                    "minimum_should_match": 1,
-                }
-            }
-        elif search_type == "options":
-            q = {
-                "bool": {
-                    "must": [{"term": {"type": "option"}}],
-                    "should": [
-                        {"wildcard": {"option_name": f"*{query}*"}},
-                        {"match": {"option_description": query}},
-                    ],
-                    "minimum_should_match": 1,
-                }
-            }
-        else:  # programs
-            q = {
-                "bool": {
-                    "must": [{"term": {"type": "package"}}],
-                    "should": [
-                        {"match": {"package_programs": {"query": query, "boost": 2}}},
-                        {"match": {"package_pname": query}},
-                    ],
-                    "minimum_should_match": 1,
-                }
-            }
+        if search_type == "options":
+            type_term, fields, wildcard_field = "option", _OPTION_SEARCH_FIELDS, "option_name"
+        else:
+            # packages and programs share the same query (programs is a specialization):
+            # `package_programs^9` in the multi_match already surfaces packages that
+            # provide the binary; the result-rendering stage then filters by exact
+            # program-name match — two layers together ensure correct program search.
+            type_term, fields, wildcard_field = "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name"
+        q = {"bool": {"must": [{"term": {"type": type_term}}, _build_search_query(query, fields, wildcard_field)]}}
 
         hits = es_query(channels[channel], q, limit)
         if not hits:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -190,6 +190,93 @@ class TestDottedPackageNameIntegration:
 
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
+class TestSearchAccuracyIntegration:
+    """Regression tests: package/option search should match the search.nixos.org frontend.
+
+    Covers three historical miss categories:
+    - Substring match: a package with pname='musicfree-desktop' must be hit by 'musicfree' (wildcard fallback)
+    - Case-insensitive: the 'MusicFree' binary name (programs field) must be hit by mixed-case queries
+    - Programs field: searching by binary name should still hit via the packages query semantics
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_package_by_partial_pname(self):
+        """Substring match: 'musicfree' should hit pname='musicfree-desktop'."""
+        result = await nix_fn(action="search", query="musicfree", type="packages", limit=5)
+        assert "musicfree-desktop" in result.lower(), f"Should match musicfree-desktop via substring, got: {result}"
+        assert "No packages found" not in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_search_package_case_insensitive(self):
+        """Case-insensitive: 'MusicFree' should hit 'musicfree-desktop'."""
+        result = await nix_fn(action="search", query="MusicFree", type="packages", limit=5)
+        assert "musicfree-desktop" in result.lower(), f"Should match case-insensitively, got: {result}"
+        assert "No packages found" not in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_search_package_by_program_name(self):
+        """Programs field hit: 'MusicFree' (binary name) must find packages providing it."""
+        result = await nix_fn(action="search", query="MusicFree", type="programs", limit=5)
+        assert "musicfree" in result.lower(), f"Should find program MusicFree, got: {result}"
+        assert "No programs found" not in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_search_option_by_partial_name(self):
+        """Options substring match: 'fontconfig' should hit 'fonts.fontconfig.*' options."""
+        result = await nix_fn(action="search", query="fontconfig", type="options", limit=5)
+        assert "fonts.fontconfig" in result.lower(), f"Should match fonts.fontconfig options, got: {result}"
+        assert "No options found" not in result
+        assert_plain_text(result)
+
+
+@pytest.mark.integration
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+class TestSearchRobustnessIntegration:
+    """Search robustness regression: multi-word queries / hyphen interchange /
+    wildcard metacharacters / overlong queries.
+
+    Covers:
+    - Multi-word + `_ ↔ -` interchange: wildcard tokenization + swap variants must hit
+      hyphenated field values.
+    - Wildcard metacharacters: user-supplied `*`, `?`, `\\` must be escaped to literals,
+      not interpreted as wildcards.
+    - Length cap: overlong queries must be truncated (no error, no service impact).
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_package_hyphen_underscore_interchange(self):
+        """'firefox_esr' should hit 'firefox-esr' (wildcard _ → - interchange)."""
+        result = await nix_fn(action="search", query="firefox_esr", type="packages", limit=5)
+        assert "firefox-esr" in result.lower(), f"Should match firefox-esr via _ → - interchange, got: {result}"
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_search_query_with_wildcard_chars_is_escaped(self):
+        """Query containing *,? must be escaped to literals, not interpreted as wildcards."""
+        result = await nix_fn(action="search", query="firefox*", type="packages", limit=5)
+        # Must not crash; must not be interpreted as a leading wildcard causing a full scan
+        # returning unrelated results (firefox* escaped ≈ prefix match for firefox).
+        assert_plain_text(result)
+        assert " API error" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_search_overlong_query_is_truncated(self):
+        """Overlong query must be truncated to _MAX_QUERY_LEN without error."""
+        long_query = "firefox" + "x" * 500
+        result = await nix_fn(action="search", query=long_query, type="packages", limit=3)
+        assert_plain_text(result)
+        assert " API error" not in result.lower()
+        # After truncation the 'firefox' prefix should still be present and match firefox packages
+        assert "firefox" in result.lower() or "No packages found" in result, (
+            f"Truncated query should still match firefox, got: {result}"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 class TestNixStatsIntegration:
     """Test nix stats action against real APIs."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,7 @@ These tests verify:
 - Edge cases and boundary conditions
 """
 
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -304,7 +305,13 @@ class TestDottedPackageNameSearch:
     @patch("mcp_nixos.sources.nixos.get_channels")
     @pytest.mark.asyncio
     async def test_search_queries_package_attr_name(self, mock_channels, mock_es):
-        """Verify that the ES query includes package_attr_name in the should clause."""
+        """Verify that the ES query includes package_attr_name as a weighted field.
+
+        New search semantics (aligned with search.nixos.org frontend) packs the
+        field list inside a dis_max/multi_match; the structural assertion is now
+        "package_attr_name appears in the query body", regardless of whether it
+        lives in a bool/should list or a multi_match fields list.
+        """
         from mcp_nixos.sources.nixos import _search_nixos
 
         mock_channels.return_value = {"unstable": "nixos-unstable"}
@@ -315,12 +322,9 @@ class TestDottedPackageNameSearch:
         # Inspect the query passed to es_query
         call_args = mock_es.call_args
         query = call_args[0][1]  # second positional arg is the query dict
-        should_clauses = query["bool"]["should"]
-
-        # There should be a clause matching package_attr_name
-        attr_name_clauses = [c for c in should_clauses if "package_attr_name" in str(c)]
-        assert len(attr_name_clauses) > 0, (
-            "ES query should include package_attr_name in should clauses to support dotted package name searches"
+        query_str = json.dumps(query)
+        assert "package_attr_name" in query_str, (
+            "ES query should reference package_attr_name to support dotted package name searches"
         )
 
     @patch("mcp_nixos.sources.nixos.es_query")
@@ -355,8 +359,8 @@ class TestDottedPackageNameSearch:
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")
     @pytest.mark.asyncio
-    async def test_search_dotted_name_extracts_pname(self, mock_channels, mock_es):
-        """Verify that dotted names also search the last component as pname."""
+    async def test_search_dotted_name_queries_full_string(self, mock_channels, mock_es):
+        """Dotted names must be sent whole into multi_match.query (no client-side pname split)."""
         from mcp_nixos.sources.nixos import _search_nixos
 
         mock_channels.return_value = {"unstable": "nixos-unstable"}
@@ -366,20 +370,13 @@ class TestDottedPackageNameSearch:
 
         call_args = mock_es.call_args
         query = call_args[0][1]
-        should_clauses = query["bool"]["should"]
-
-        # The pname clause should search for "matplotlib" (the last component),
-        # not the full dotted string
-        pname_clauses = [c for c in should_clauses if "match" in c and "package_pname" in c.get("match", {})]
-        assert len(pname_clauses) > 0, "Should have a package_pname match clause"
-        pname_query = pname_clauses[0]["match"]["package_pname"]
-        if isinstance(pname_query, dict):
-            pname_value = pname_query["query"]
-        else:
-            pname_value = pname_query
-        assert pname_value == "matplotlib", (
-            f"package_pname should search for 'matplotlib' (last component), got '{pname_value}'"
+        query_str = json.dumps(query)
+        # multi_match.query carries the full dotted string; package_pname is one
+        # of the weighted fields inside the same multi_match.
+        assert "python314Packages.matplotlib" in query_str, (
+            "multi_match.query should carry the full dotted name, got: " + query_str
         )
+        assert "package_pname" in query_str, "package_pname must remain a searchable field"
 
     @patch("mcp_nixos.sources.nixos.es_query")
     @patch("mcp_nixos.sources.nixos.get_channels")


### PR DESCRIPTION
## AI Usage Disclosure
*AI-assisted: investigated, written, and tested with OpenCode (GLM-5.2).*

## Summary

`_search_nixos` builds ES `bool/should/match` queries that miss legitimate substring matches. Searching for `musicfree` returns zero results, even though `musicfree-desktop` exists in the index — because ES standard analyzer keeps `musicfree-desktop` as a single hyphenated token, and `match` on `package_pname` / `package_attr_name` cannot match the un-hyphenated substring.

The search.nixos.org web frontend doesn't have this problem. Its Elm source (`frontend/src/Page/Packages.elm` / `Search.elm`) builds a `dis_max(multi_match cross_fields + case_insensitive wildcard fallback)` query with tokenization and `_ ↔ -` variants, so `musicfree` matches `musicfree-desktop` via the wildcard clause, and `steam_runtime` matches `steam-runtime` via the `_ ↔ -` swap.

**User-visible symptom:** `nix({"action":"search","query":"MusicFree"})` → "No packages found", while https://search.nixos.org/packages?query=MusicFree returns `musicfree-desktop`.

## What changed

- **`mcp_nixos/sources/nixos.py`**:
  - Extract two helpers: `_build_search_query(query, fields, wildcard_field)` and `_wildcard_clauses(query, field)`. packages/options/programs all route through `_build_search_query` now.
  - `dis_max(multi_match(cross_fields, whitespace, operator=and) + wildcard fallback)` replaces the old `bool/should/match`. Field weights mirror the frontend Elm source.
  - options search only references fields that actually exist on the NixOS options index (`option_name`, `option_description`). The frontend query template also includes `option_name_query`, `service_package(s)`, `flake_name` — these are template fields for the hm/darwin/flakes indices and are silently ignored by ES against the NixOS options index; dropping them avoids confusion and matches actual effective behavior.
  - `_wildcard_clauses` tokenizes the query, adds `_ ↔ -` swap variants per token, and generates one `case_insensitive` wildcard clause per variant — matching the frontend's `Search.elm` behavior for multi-word and hyphenated queries.
  - `_normalize_query` centralizes input preprocessing at the `_search_nixos` entry: `trim` + 200-char truncation (wildcard is term-level scan; overlong queries are slow) + escape `*`/`?`/`\\` (prevent wildcard metacharacter injection).
  - packages and programs share the same query builder (programs is a specialization — `package_programs^9` in the multi_match already surfaces packages providing the binary; the result rendering then filters by exact program-name match).
- **`tests/test_integration.py`**: added `TestSearchAccuracyIntegration` (4 cases: partial-pname, case-insensitive, program-name, option-substring) and `TestSearchRobustnessIntegration` (3 cases: `_ ↔ -` interchange, wildcard metacharacter escaping, overlong query truncation).
- **`tests/test_tools.py`**: updated `TestDottedPackageNameSearch` — two unit tests previously asserted on the old `bool/should` structure. They now assert on the equivalent property in the new `dis_max`/`multi_match` structure (presence of `package_attr_name` field, full dotted string in `multi_match.query`).

## Smoke test against the live backend

```text
Before:  nix({"action":"search","query":"MusicFree"}) → "No packages found matching 'MusicFree'"
After:   nix({"action":"search","query":"MusicFree"}) → "Found 1 packages matching 'MusicFree':\n\n* musicfree-desktop (0.0.8)\n  Customizable music player with plugin support"

Before:  nix({"action":"search","query":"musicfree"}) → "No packages found"
After:   nix({"action":"search","query":"musicfree"}) → "musicfree-desktop" (wildcard *musicfree* matches)

Before:  nix({"action":"search","query":"firefox_esr"}) → unrelated results (no _ ↔ - swap)
After:   nix({"action":"search","query":"firefox_esr"}) → 6 firefox-esr* packages (wildcard *firefox-esr* variant matches)
```

*(Tested 2026-08-11 against `nixos-26.05`; package counts are a point-in-time snapshot.)*

## Test plan

- [x] `pytest -m "not integration"` — 370 passed, 76 deselected
- [x] `ruff check mcp_nixos/ tests/` — clean
- [x] `ruff format --check mcp_nixos/ tests/` — clean (31 files already formatted)
- [x] `mypy mcp_nixos/` — no issues in 20 source files
- [x] Live integration tests pass (7 new + 9 existing search-related): substring, case-insensitive, `_ ↔ -` swap, wildcard metachar escaping, overlong query truncation, dotted names, firefox/nginx regressions

## Notes

- Field-weight constants (`_PACKAGE_SEARCH_FIELDS` / `_OPTION_SEARCH_FIELDS`) are hardcoded to mirror the Elm source. The frontend is the SSOT for relevance ranking; making these configurable would risk drift from upstream search behavior.
- Query length cap is 200 characters — covers normal package names and option paths while blocking LLM-generated paragraphs that would make wildcard substring scans expensive.
- `_info_nixos` is untouched (it uses `term`-exact matches on `package_attr_name` / `option_name`, independent of the search query builder); behavior unchanged.
- No `Resolves #N` — I didn't find an existing issue tracking this. Happy to open one first if the maintainer prefers the issue-first workflow.
