### PR TITLE
fix(ci): build the distribution with --no-isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Build Python distribution
       run: |
-        nix develop --command python -m build
+        nix develop --command python -m build --no-isolation
         ls -la dist/
 
     - name: Validate package metadata

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build Python package
         run: |
-          nix develop --command python -m build
+          nix develop --command python -m build --no-isolation
           nix develop --command twine check dist/*
 
       - name: Upload build artifacts

--- a/flake.nix
+++ b/flake.nix
@@ -363,7 +363,11 @@
                 category = "build";
                 name = "build";
                 help = "build the Python wheel + sdist into dist/";
-                command = "cd \"$PRJ_ROOT\" && python -m build \"$@\"";
+                # --no-isolation: use the hatchling pinned by this flake instead of
+                # letting `build` fetch the newest one from PyPI. Recent hatchling
+                # releases emit Metadata-Version 2.5, which `twine check` — and
+                # PyPI's upload API — still reject.
+                command = "cd \"$PRJ_ROOT\" && python -m build --no-isolation \"$@\"";
               }
               {
                 category = "build";


### PR DESCRIPTION
## AI Usage Disclosure
*AI-assisted: investigated, written, and tested with Claude Code; peer-reviewed with Codex.*

## Summary

The `build` job has been failing on every PR since roughly 2026-08-10:

```
Checking dist/mcp_nixos-3.0.0-py3-none-any.whl: ERROR
  InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Reproduced on unmodified `main` in a clean worktree, so it is not caused by any recent code change.

## Root cause

`python -m build` defaults to **build isolation**: it creates a fresh venv and installs the newest `hatchling` from PyPI, ignoring the one this flake pins. Recent hatchling releases emit `Metadata-Version: 2.5`.

`twine` 6.2.0 monkey-patches `packaging.metadata._VALID_METADATA_VERSIONS` down to what the PyPI upload API actually accepts, which currently tops out at 2.4 (`twine/package.py:32`). Bumping `packaging` does not help — the cap is twine's, not `packaging`'s.

This is not only a CI annoyance: `publish.yml` runs the same `twine check`, and `pypa/gh-action-pypi-publish` uploads through twine, so the next release would have failed at the PyPI step.

## What changed

`python -m build` → `python -m build --no-isolation` in the three places it runs:

- `flake.nix` — the `build` devshell command
- `.github/workflows/ci.yml`
- `.github/workflows/publish.yml`

With isolation off, the build uses the hatchling already in the flake's Python env (1.29.0, whose `DEFAULT_METADATA_VERSION` is `2.4`), which is the pin this repo intends to build against anyway.

## Verification

```text
$ nix develop -c bash -c 'python -m build --no-isolation && twine check dist/*'
Successfully built mcp_nixos-3.0.0.tar.gz and mcp_nixos-3.0.0-py3-none-any.whl
Checking dist/mcp_nixos-3.0.0-py3-none-any.whl: PASSED
Checking dist/mcp_nixos-3.0.0.tar.gz: PASSED

$ unzip -p dist/*.whl '*/METADATA' | head -1
Metadata-Version: 2.4
```

`nix flake check` evaluates clean.

## Notes

- An alternative fix would be waiting for a twine release that accepts 2.5, but that is gated on PyPI accepting 2.5 uploads. `--no-isolation` is the right default here regardless: it makes the wheel a function of the flake pin rather than of whatever is newest on PyPI at build time.