### PR TITLE
fix(search): restore exact-match ranking and correct result counts

### DIFF
--- a/mcp_nixos/sources/base.py
+++ b/mcp_nixos/sources/base.py
@@ -70,11 +70,19 @@ def get_channel_suggestions(invalid_channel: str) -> str:
     return f"Available channels: {', '.join(suggestions)}"
 
 
-def es_query(index: str, query: dict[str, Any], size: int = 20) -> list[dict[str, Any]]:
+def es_query(
+    index: str, query: dict[str, Any], size: int = 20, rescore: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    """Run a search against the NixOS Elasticsearch index.
+
+    `rescore` is a top-level search-body key (not part of `query`), used to
+    re-rank the top window after the main query scores it.
+    """
+    body: dict[str, Any] = {"query": query, "size": size}
+    if rescore:
+        body["rescore"] = rescore
     try:
-        resp = requests.post(
-            f"{NIXOS_API}/{index}/_search", json={"query": query, "size": size}, auth=NIXOS_AUTH, timeout=10
-        )
+        resp = requests.post(f"{NIXOS_API}/{index}/_search", json=body, auth=NIXOS_AUTH, timeout=10)
         resp.raise_for_status()
         data = resp.json()
         if isinstance(data, dict) and "hits" in data:

--- a/mcp_nixos/sources/nixos.py
+++ b/mcp_nixos/sources/nixos.py
@@ -8,23 +8,34 @@ from ..utils import error
 from .base import es_query, get_channel_suggestions, get_channels
 
 # Field weights mirror the search.nixos.org frontend Elm source
-# (nixos-search repo: frontend/src/Page/Packages.elm — defaultSearchFields).
+# (nixos-search repo: frontend/src/Search/Query.elm — packagesBody / optionsBody).
 # Verified against live ES index document keys — only fields that actually exist
 # on the NixOS packages / options indices are referenced.
 # Note: the frontend options query template also references option_name_query,
 # service_package(s), flake_name — those are template fields for the
 # home-manager / darwin / flakes indices and are silently ignored by ES against
 # the NixOS options index, so we omit them here.
-_PACKAGE_SEARCH_FIELDS = [
-    "package_attr_name^9",
-    "package_programs^9",
-    "package_pname^6",
-    "package_description^1.3",
-    "package_longDescription^1",
+_PACKAGE_SEARCH_FIELDS: list[tuple[str, float]] = [
+    ("package_attr_name", 9.0),
+    ("package_programs", 9.0),
+    ("package_pname", 6.0),
+    ("package_description", 1.3),
+    ("package_longDescription", 1.0),
 ]
-_OPTION_SEARCH_FIELDS = [
-    "option_name^6",
-    "option_description^1",
+_OPTION_SEARCH_FIELDS: list[tuple[str, float]] = [
+    ("option_name", 6.0),
+    ("option_description", 1.0),
+]
+
+# Fields the phrase clause scores over for multi-word queries (upstream `phraseFields`).
+_PACKAGE_PHRASE_FIELDS = ["package_description^3", "package_longDescription^1"]
+_OPTION_PHRASE_FIELDS = ["option_description^3"]
+
+# `rank_feature` popularity signals — packages only (upstream `popularityClauses`).
+# Each entry is (field, saturation pivot).
+_PACKAGE_POPULARITY: list[tuple[str, float]] = [
+    ("package_repology_repos", 20.0),
+    ("package_dep_count", 1000.0),
 ]
 
 # Query length cap: wildcard is a term-level scan, so an overlong query makes
@@ -43,69 +54,149 @@ def _hyphen_variants(token: str) -> set[str]:
     return {token, token.replace("_", "-"), token.replace("-", "_")}
 
 
-def _wildcard_clauses(query: str, field: str) -> list[dict[str, Any]]:
-    """Build case_insensitive wildcard clauses, mirroring the frontend Elm (Search.elm).
+def _query_words(query: str) -> list[str]:
+    """Lower-case the query and split it into clause-safe words.
 
-    1. The whole query string is a candidate (covers substring matches like
-       `musicfree` hitting `musicfree-desktop`).
-    2. Each whitespace-separated token gets its own wildcard clause (multi-word queries).
-    3. `_ ↔ -` swap variants via `_hyphen_variants`.
-
-    Precondition: `query` must already be normalized (trimmed) by the caller —
-    `_search_nixos` calls `_normalize_query` before reaching here, which turns
-    pure-whitespace input into an empty string. An empty `query` yields zero
-    clauses, leaving the dis_max branch inactive.
+    ES wildcard metacharacters (`*`, `?`, `\\`) are stripped rather than escaped.
+    None of them can occur in a nix attribute path, option name or binary name,
+    so a query like `firefox*` means "firefox" — escaping it instead would make
+    every clause search for a literal asterisk and return nothing.
     """
-    lowered = query.lower()
-    tokens = [lowered, *lowered.split()]
+    cleaned = query.lower().translate({ord(c): None for c in "*?\\"})
+    return cleaned.split()
+
+
+def _wildcard_clauses(words: list[str], field: str) -> list[dict[str, Any]]:
+    """Build case_insensitive wildcard clauses, mirroring upstream `searchFields`.
+
+    One clause per query word, plus its `_ ↔ -` swap variants, so `musicfree`
+    hits `musicfree-desktop` and `firefox_esr` hits `firefox-esr` — matches the
+    analyzer would otherwise miss. An empty word list yields zero clauses.
+    """
     candidates: set[str] = set()
-    for token in tokens:
-        candidates |= _hyphen_variants(token)
+    for word in words:
+        candidates |= _hyphen_variants(word)
     candidates.discard("")
     return [{"wildcard": {field: {"value": f"*{w}*", "case_insensitive": True}}} for w in sorted(candidates)]
 
 
 def _normalize_query(query: str) -> str:
-    """Centralized input preprocessing at the `_search_nixos` entry: trim, truncate, escape.
+    """Trim and length-cap the raw query at the `_search_nixos` entry.
 
-    Escapes `*`, `?`, `\\` so they are treated as literals by ES wildcard semantics
-    (prevents metacharacter injection). Length cap blocks LLM-generated paragraphs
-    that would make wildcard substring scans expensive.
+    The result is what the user sees echoed back in the response; clause-building
+    goes through `_query_words`, which does the lower-casing and metacharacter
+    stripping.
     """
-    q = query.strip()
-    if len(q) > _MAX_QUERY_LEN:
-        q = q[:_MAX_QUERY_LEN]
-    return q.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
+    return query.strip()[:_MAX_QUERY_LEN]
 
 
-def _build_search_query(query: str, fields: list[str], wildcard_field: str) -> dict[str, Any]:
+def _weighted_fields(fields: list[tuple[str, float]]) -> list[str]:
+    """Expand (field, weight) pairs into upstream's `field^w` + `field.*^(w*0.6)` list.
+
+    The `.*` variant lets multi-field sub-fields (e.g. `package_attr_name.edge`)
+    contribute at a lower weight, exactly as upstream `searchFields` does.
+    """
+    expanded: list[str] = []
+    for name, weight in fields:
+        expanded.append(f"{name}^{weight}")
+        expanded.append(f"{name}.*^{round(weight * 0.6, 4)}")
+    return expanded
+
+
+def _should_clauses(
+    words: list[str], main_field: str, phrase_fields: list[str], popularity: list[tuple[str, float]]
+) -> list[dict[str, Any]]:
+    """Relevance boosts that decide ordering (upstream `shouldClauses` + `popularityClauses`).
+
+    Without these the dis_max alone ranks `firefox-esr-153-unwrapped` above
+    `firefox` for the query `firefox`:
+    - exact term on the primary field (boost 100) — an exact name always wins
+    - case-insensitive prefix (boost 20)
+    - phrase match over the description fields (boost 80, multi-word only)
+    - `rank_feature` popularity saturation (packages only)
+    """
+    clauses: list[dict[str, Any]] = []
+    if words:
+        joined = "".join(words)
+        clauses.append({"term": {main_field: {"value": joined, "boost": 100.0}}})
+        clauses.append({"prefix": {main_field: {"value": joined, "boost": 20.0, "case_insensitive": True}}})
+        if len(words) > 1:
+            clauses.append(
+                {
+                    "constant_score": {
+                        "filter": {
+                            "multi_match": {"type": "phrase", "query": " ".join(words), "fields": phrase_fields}
+                        },
+                        "boost": 80.0,
+                    }
+                }
+            )
+    clauses.extend(
+        {"rank_feature": {"field": field, "boost": 5.0, "saturation": {"pivot": pivot}}} for field, pivot in popularity
+    )
+    return clauses
+
+
+def _build_search_query(
+    query: str,
+    type_term: str,
+    fields: list[tuple[str, float]],
+    main_field: str,
+    phrase_fields: list[str],
+    popularity: list[tuple[str, float]],
+) -> dict[str, Any]:
     """Build the ES query body mirroring the search.nixos.org frontend semantics.
 
-    `dis_max(multi_match + wildcard fallback)`:
+    `bool(filter=type, must=dis_max(multi_match + wildcards), should=boosts)`:
     - `multi_match(cross_fields, whitespace analyzer, operator=and)` does the
-      weighted cross-field match (tie_breaker / auto_generate_synonyms_phrase_query
-      values come straight from the frontend Elm source).
-    - The wildcard fallback (tokenized + `_ ↔ -` swapped + case_insensitive)
-      covers substring and hyphen-variant matches the analyzer would otherwise miss.
+      weighted cross-field match. The query is lower-cased because the
+      `whitespace` analyzer does not fold case, so `MusicFree` would otherwise
+      never match the lower-cased index terms.
+    - The wildcard fallback covers substring and `_ ↔ -` hyphen variants.
+    - `should` carries the boosts that determine ordering (see `_should_clauses`).
     """
+    words = _query_words(query)
     return {
-        "dis_max": {
-            "tie_breaker": 0.7,
-            "queries": [
+        "bool": {
+            "filter": [{"term": {"type": type_term}}],
+            "must": [
                 {
-                    "multi_match": {
-                        "type": "cross_fields",
-                        "query": query,
-                        "analyzer": "whitespace",
-                        "auto_generate_synonyms_phrase_query": False,
-                        "operator": "and",
-                        "fields": fields,
+                    "dis_max": {
+                        "tie_breaker": 0.7,
+                        "queries": [
+                            {
+                                "multi_match": {
+                                    "type": "cross_fields",
+                                    "query": " ".join(words),
+                                    "analyzer": "whitespace",
+                                    "auto_generate_synonyms_phrase_query": False,
+                                    "operator": "and",
+                                    "fields": _weighted_fields(fields),
+                                }
+                            },
+                            *_wildcard_clauses(words, main_field),
+                        ],
                     }
-                },
-                *_wildcard_clauses(query, wildcard_field),
+                }
             ],
+            "should": _should_clauses(words, main_field, phrase_fields, popularity),
         }
     }
+
+
+# Upstream `rescoreQuery`: re-rank the top window by inverse attribute-name
+# length so short, canonical names (`firefox`) outrank long derived ones
+# (`firefox-esr-153-unwrapped`) at equal relevance. Packages only — the options
+# index has no equivalent primary-name length signal upstream rescores on.
+_PACKAGE_RESCORE: dict[str, Any] = {
+    "window_size": 100,
+    "query": {
+        "rescore_query": {
+            "function_score": {"script_score": {"script": {"source": "1.0 / doc['package_attr_name'].value.length()"}}}
+        },
+        "rescore_query_weight": 20.0,
+    },
+}
 
 
 def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str:
@@ -121,26 +212,49 @@ def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str
     if channel not in channels:
         return error(f"Invalid channel '{channel}'. {get_channel_suggestions(channel)}")
 
-    # Centralized preprocessing: trim + length truncation + wildcard metachar escaping
-    # (SSOT — downstream helpers assume normalized input).
+    # Centralized preprocessing: trim + length cap (SSOT — downstream helpers
+    # assume normalized input). Wildcard metacharacters are escaped per-clause.
     query = _normalize_query(query)
+    if not _query_words(query):
+        # Nothing searchable left (empty or metacharacter-only query) — an empty
+        # multi_match would just be a slow way to match nothing.
+        return f"No {search_type} found matching '{query}'"
 
     try:
         if search_type == "options":
-            type_term, fields, wildcard_field = "option", _OPTION_SEARCH_FIELDS, "option_name"
+            q = _build_search_query(query, "option", _OPTION_SEARCH_FIELDS, "option_name", _OPTION_PHRASE_FIELDS, [])
+            rescore = None
+        elif search_type == "programs":
+            # Programs search hits the same index as packages, but the primary
+            # field is the binary name: `rg` is provided by `ripgrep`, whose attr
+            # name shares nothing with the query. Boosting and wildcarding
+            # package_attr_name here pushes the real providers out of the result
+            # window, so programs anchors on package_programs instead — and skips
+            # the attr-name-length rescore, which is meaningless for binaries.
+            q = _build_search_query(
+                query, "package", _PACKAGE_SEARCH_FIELDS, "package_programs", _PACKAGE_PHRASE_FIELDS, []
+            )
+            rescore = None
         else:
-            # packages and programs share the same query (programs is a specialization):
-            # `package_programs^9` in the multi_match already surfaces packages that
-            # provide the binary; the result-rendering stage then filters by exact
-            # program-name match — two layers together ensure correct program search.
-            type_term, fields, wildcard_field = "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name"
-        q = {"bool": {"must": [{"term": {"type": type_term}}, _build_search_query(query, fields, wildcard_field)]}}
+            q = _build_search_query(
+                query,
+                "package",
+                _PACKAGE_SEARCH_FIELDS,
+                "package_attr_name",
+                _PACKAGE_PHRASE_FIELDS,
+                _PACKAGE_POPULARITY,
+            )
+            rescore = _PACKAGE_RESCORE
 
-        hits = es_query(channels[channel], q, limit)
+        hits = es_query(channels[channel], q, limit, rescore=rescore)
         if not hits:
             return f"No {search_type} found matching '{query}'"
 
-        results = [f"Found {len(hits)} {search_type} matching '{query}':\n"]
+        # Count what is actually rendered, not what ES returned: the programs
+        # branch drops hits whose program list has no exact match, so `len(hits)`
+        # would overstate the result count.
+        shown = 0
+        results: list[str] = []
         for hit in hits:
             src = hit.get("_source", {})
             if search_type == "packages":
@@ -153,6 +267,7 @@ def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str
                 if desc:
                     results.append(f"  {desc}")
                 results.append("")
+                shown += 1
             elif search_type == "options":
                 name = src.get("option_name", "")
                 opt_type = src.get("option_type", "")
@@ -166,6 +281,7 @@ def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str
                 if desc:
                     results.append(f"  {desc}")
                 results.append("")
+                shown += 1
             else:  # programs
                 programs = src.get("package_programs", [])
                 pkg_name = src.get("package_pname", "")
@@ -174,7 +290,10 @@ def _search_nixos(query: str, search_type: str, limit: int, channel: str) -> str
                 for prog in matched_programs:
                     results.append(f"* {prog} (provided by {pkg_name})")
                     results.append("")
-        return "\n".join(results).strip()
+                    shown += 1
+        if not shown:
+            return f"No {search_type} found matching '{query}'"
+        return "\n".join([f"Found {shown} {search_type} matching '{query}':\n", *results]).strip()
     except Exception as e:
         return error(str(e))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -219,8 +219,24 @@ class TestSearchAccuracyIntegration:
     async def test_search_package_by_program_name(self):
         """Programs field hit: 'MusicFree' (binary name) must find packages providing it."""
         result = await nix_fn(action="search", query="MusicFree", type="programs", limit=5)
-        assert "musicfree" in result.lower(), f"Should find program MusicFree, got: {result}"
+        # The header echoes the query, so assert on the rendered entry instead.
+        assert "provided by musicfree-desktop" in result.lower(), f"Should find program MusicFree, got: {result}"
         assert "No programs found" not in result
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_search_program_by_indirect_binary_name(self):
+        """`rg` is provided by `ripgrep` — a package whose attr name shares nothing with the query."""
+        result = await nix_fn(action="search", query="rg", type="programs", limit=10)
+        assert "provided by ripgrep" in result.lower(), f"Should find rg provided by ripgrep, got: {result}"
+        assert_plain_text(result)
+
+    @pytest.mark.asyncio
+    async def test_exact_package_name_ranks_first(self):
+        """`firefox` must outrank derived names like `firefox-esr-153-unwrapped`."""
+        result = await nix_fn(action="search", query="firefox", type="packages", limit=5)
+        first_entry = next(line for line in result.splitlines() if line.startswith("* "))
+        assert first_entry.startswith("* firefox ("), f"Exact match should rank first, got: {result}"
         assert_plain_text(result)
 
     @pytest.mark.asyncio
@@ -241,8 +257,8 @@ class TestSearchRobustnessIntegration:
     Covers:
     - Multi-word + `_ ↔ -` interchange: wildcard tokenization + swap variants must hit
       hyphenated field values.
-    - Wildcard metacharacters: user-supplied `*`, `?`, `\\` must be escaped to literals,
-      not interpreted as wildcards.
+    - Wildcard metacharacters: user-supplied `*`, `?`, `\\` are stripped, so the rest of
+      the query still searches normally.
     - Length cap: overlong queries must be truncated (no error, no service impact).
     """
 
@@ -254,13 +270,13 @@ class TestSearchRobustnessIntegration:
         assert_plain_text(result)
 
     @pytest.mark.asyncio
-    async def test_search_query_with_wildcard_chars_is_escaped(self):
-        """Query containing *,? must be escaped to literals, not interpreted as wildcards."""
+    async def test_search_query_with_wildcard_chars_is_stripped(self):
+        """`firefox*` must search for "firefox" — metacharacters are dropped, not escaped."""
         result = await nix_fn(action="search", query="firefox*", type="packages", limit=5)
-        # Must not crash; must not be interpreted as a leading wildcard causing a full scan
-        # returning unrelated results (firefox* escaped ≈ prefix match for firefox).
         assert_plain_text(result)
-        assert " API error" not in result.lower()
+        assert "API error" not in result
+        assert "\\" not in result, f"Escape characters must not leak into the response, got: {result}"
+        assert "* firefox (" in result, f"Should still match firefox packages, got: {result}"
 
     @pytest.mark.asyncio
     async def test_search_overlong_query_is_truncated(self):
@@ -268,7 +284,7 @@ class TestSearchRobustnessIntegration:
         long_query = "firefox" + "x" * 500
         result = await nix_fn(action="search", query=long_query, type="packages", limit=3)
         assert_plain_text(result)
-        assert " API error" not in result.lower()
+        assert "API error" not in result
         # After truncation the 'firefox' prefix should still be present and match firefox packages
         assert "firefox" in result.lower() or "No packages found" in result, (
             f"Truncated query should still match firefox, got: {result}"

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -1,0 +1,270 @@
+"""Unit tests for the NixOS Elasticsearch query builder.
+
+These cover the pure query-construction helpers in `mcp_nixos.sources.nixos`
+without touching the network: the shape of the emitted ES body, the relevance
+boosts that decide result ordering, and the input normalization applied before
+any clause is built.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from mcp_nixos.sources.nixos import (
+    _MAX_QUERY_LEN,
+    _OPTION_SEARCH_FIELDS,
+    _PACKAGE_POPULARITY,
+    _PACKAGE_RESCORE,
+    _PACKAGE_SEARCH_FIELDS,
+    _build_search_query,
+    _hyphen_variants,
+    _normalize_query,
+    _query_words,
+    _search_nixos,
+    _should_clauses,
+    _weighted_fields,
+    _wildcard_clauses,
+)
+
+
+def _wildcard_values(clauses, field):
+    return [c["wildcard"][field]["value"] for c in clauses]
+
+
+@pytest.mark.unit
+class TestQueryNormalization:
+    """`_normalize_query` produces the string echoed back to the user."""
+
+    def test_trims_whitespace(self):
+        assert _normalize_query("  firefox  ") == "firefox"
+
+    def test_truncates_overlong_query(self):
+        assert len(_normalize_query("x" * 500)) == _MAX_QUERY_LEN
+
+    def test_preserves_metacharacters_for_display(self):
+        # Escaping here would leak backslashes into the response text.
+        assert _normalize_query("firefox*") == "firefox*"
+
+
+@pytest.mark.unit
+class TestQueryWords:
+    """`_query_words` produces the clause-safe word list."""
+
+    def test_lowercases(self):
+        assert _query_words("MusicFree") == ["musicfree"]
+
+    def test_splits_on_whitespace(self):
+        assert _query_words("text editor") == ["text", "editor"]
+
+    def test_strips_wildcard_metacharacters(self):
+        # Stripped, not escaped: `firefox*` must still search for "firefox".
+        assert _query_words("firefox*") == ["firefox"]
+        assert _query_words("what?") == ["what"]
+        assert _query_words("a\\b") == ["ab"]
+
+    def test_metacharacter_only_query_is_empty(self):
+        assert _query_words("*?") == []
+        assert _query_words("   ") == []
+
+
+@pytest.mark.unit
+class TestHyphenVariants:
+    def test_underscore_and_dash_are_interchangeable(self):
+        assert _hyphen_variants("firefox_esr") == {"firefox_esr", "firefox-esr"}
+
+    def test_plain_word_has_single_variant(self):
+        assert _hyphen_variants("firefox") == {"firefox"}
+
+
+@pytest.mark.unit
+class TestWildcardClauses:
+    def test_wraps_each_word_in_substring_wildcards(self):
+        clauses = _wildcard_clauses(["musicfree"], "package_attr_name")
+        assert _wildcard_values(clauses, "package_attr_name") == ["*musicfree*"]
+
+    def test_emits_hyphen_variants(self):
+        values = _wildcard_values(_wildcard_clauses(["firefox_esr"], "package_attr_name"), "package_attr_name")
+        assert sorted(values) == ["*firefox-esr*", "*firefox_esr*"]
+
+    def test_clauses_are_case_insensitive(self):
+        clause = _wildcard_clauses(["vim"], "package_attr_name")[0]
+        assert clause["wildcard"]["package_attr_name"]["case_insensitive"] is True
+
+    def test_multi_word_query_yields_one_clause_per_word(self):
+        values = _wildcard_values(_wildcard_clauses(["docker", "compose"], "package_attr_name"), "package_attr_name")
+        assert sorted(values) == ["*compose*", "*docker*"]
+
+    def test_empty_word_list_yields_no_clauses(self):
+        assert _wildcard_clauses([], "package_attr_name") == []
+
+
+@pytest.mark.unit
+class TestWeightedFields:
+    def test_expands_each_field_into_base_and_subfield(self):
+        assert _weighted_fields([("package_pname", 6.0)]) == ["package_pname^6.0", "package_pname.*^3.6"]
+
+    def test_subfield_weight_is_60_percent(self):
+        expanded = _weighted_fields([("package_description", 1.3)])
+        assert expanded[1] == "package_description.*^0.78"
+
+
+@pytest.mark.unit
+class TestShouldClauses:
+    """The boosts that decide ordering — without them `firefox` loses to `firefox-esr-153-unwrapped`."""
+
+    def test_exact_term_boost_dominates(self):
+        clauses = _should_clauses(["firefox"], "package_attr_name", [], [])
+        term = next(c for c in clauses if "term" in c)
+        assert term["term"]["package_attr_name"] == {"value": "firefox", "boost": 100.0}
+
+    def test_prefix_clause_is_case_insensitive(self):
+        clauses = _should_clauses(["firefox"], "package_attr_name", [], [])
+        prefix = next(c for c in clauses if "prefix" in c)
+        assert prefix["prefix"]["package_attr_name"]["case_insensitive"] is True
+        assert prefix["prefix"]["package_attr_name"]["boost"] == 20.0
+
+    def test_multi_word_query_adds_phrase_clause(self):
+        clauses = _should_clauses(["text", "editor"], "package_attr_name", ["package_description^3"], [])
+        phrase = next(c for c in clauses if "constant_score" in c)
+        assert phrase["constant_score"]["filter"]["multi_match"]["query"] == "text editor"
+        assert phrase["constant_score"]["boost"] == 80.0
+
+    def test_single_word_query_has_no_phrase_clause(self):
+        clauses = _should_clauses(["firefox"], "package_attr_name", ["package_description^3"], [])
+        assert not any("constant_score" in c for c in clauses)
+
+    def test_words_are_joined_for_term_and_prefix(self):
+        # Upstream concatenates the words with no separator.
+        clauses = _should_clauses(["rust", "analyzer"], "package_attr_name", [], [])
+        term = next(c for c in clauses if "term" in c)
+        assert term["term"]["package_attr_name"]["value"] == "rustanalyzer"
+
+    def test_popularity_signals_become_rank_features(self):
+        clauses = _should_clauses(["firefox"], "package_attr_name", [], _PACKAGE_POPULARITY)
+        features = [c["rank_feature"] for c in clauses if "rank_feature" in c]
+        assert [f["field"] for f in features] == ["package_repology_repos", "package_dep_count"]
+        assert features[0]["saturation"]["pivot"] == 20.0
+
+    def test_empty_word_list_yields_only_popularity(self):
+        assert _should_clauses([], "package_attr_name", [], []) == []
+
+
+@pytest.mark.unit
+class TestBuildSearchQuery:
+    def test_type_filter_is_non_scoring(self):
+        q = _build_search_query("firefox", "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name", [], [])
+        assert q["bool"]["filter"] == [{"term": {"type": "package"}}]
+
+    def test_multi_match_is_lowercased(self):
+        # The whitespace analyzer does not fold case, so the query must be lowered
+        # before it reaches ES or `MusicFree` never matches.
+        q = _build_search_query("MusicFree", "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name", [], [])
+        multi_match = q["bool"]["must"][0]["dis_max"]["queries"][0]["multi_match"]
+        assert multi_match["query"] == "musicfree"
+        assert multi_match["type"] == "cross_fields"
+        assert multi_match["operator"] == "and"
+
+    def test_dis_max_carries_wildcard_fallback(self):
+        q = _build_search_query("musicfree", "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name", [], [])
+        queries = q["bool"]["must"][0]["dis_max"]["queries"]
+        assert q["bool"]["must"][0]["dis_max"]["tie_breaker"] == 0.7
+        assert any("wildcard" in clause for clause in queries)
+
+    def test_dotted_name_is_sent_whole(self):
+        q = _build_search_query(
+            "python314Packages.matplotlib", "package", _PACKAGE_SEARCH_FIELDS, "package_attr_name", [], []
+        )
+        multi_match = q["bool"]["must"][0]["dis_max"]["queries"][0]["multi_match"]
+        assert multi_match["query"] == "python314packages.matplotlib"
+
+    def test_options_query_filters_on_option_type(self):
+        q = _build_search_query("fontconfig", "option", _OPTION_SEARCH_FIELDS, "option_name", [], [])
+        assert q["bool"]["filter"] == [{"term": {"type": "option"}}]
+        assert "option_name^6.0" in q["bool"]["must"][0]["dis_max"]["queries"][0]["multi_match"]["fields"]
+
+
+@pytest.mark.unit
+class TestSearchWiring:
+    """`_search_nixos` picks the right primary field and rescore per search type."""
+
+    @staticmethod
+    def _run(search_type, query="vim", hits=None):
+        with (
+            patch("mcp_nixos.sources.nixos.get_channels", return_value={"unstable": "latest-nixos-unstable"}),
+            patch("mcp_nixos.sources.nixos.es_query", Mock(return_value=hits or [])) as mock_es,
+        ):
+            _search_nixos(query, search_type, 5, "unstable")
+        return mock_es.call_args
+
+    def test_packages_anchor_on_attr_name_and_rescore(self):
+        args, kwargs = self._run("packages")
+        should = args[1]["bool"]["should"]
+        assert any("package_attr_name" in c.get("term", {}) for c in should)
+        assert kwargs["rescore"] == _PACKAGE_RESCORE
+
+    def test_programs_anchor_on_package_programs_without_rescore(self):
+        # `rg` is provided by `ripgrep`: boosting package_attr_name would push the
+        # real provider out of the result window.
+        args, kwargs = self._run("programs", query="rg")
+        should = args[1]["bool"]["should"]
+        assert any("package_programs" in c.get("term", {}) for c in should)
+        assert not any("package_attr_name" in c.get("term", {}) for c in should)
+        assert kwargs["rescore"] is None
+
+    def test_options_use_option_name_without_rescore(self):
+        args, kwargs = self._run("options", query="fontconfig")
+        should = args[1]["bool"]["should"]
+        assert any("option_name" in c.get("term", {}) for c in should)
+        assert kwargs["rescore"] is None
+
+    def test_metacharacter_only_query_skips_the_request(self):
+        with (
+            patch("mcp_nixos.sources.nixos.get_channels", return_value={"unstable": "latest-nixos-unstable"}),
+            patch("mcp_nixos.sources.nixos.es_query", Mock()) as mock_es,
+        ):
+            result = _search_nixos("*", "packages", 5, "unstable")
+        mock_es.assert_not_called()
+        assert result == "No packages found matching '*'"
+
+
+@pytest.mark.unit
+class TestResultCount:
+    """The reported count must match the number of rendered entries."""
+
+    @staticmethod
+    def _program_hit(programs, pname):
+        return {"_source": {"package_programs": programs, "package_pname": pname}}
+
+    def _search_programs(self, hits, query="vim"):
+        with (
+            patch("mcp_nixos.sources.nixos.get_channels", return_value={"unstable": "latest-nixos-unstable"}),
+            patch("mcp_nixos.sources.nixos.es_query", Mock(return_value=hits)),
+        ):
+            return _search_nixos(query, "programs", 5, "unstable")
+
+    def test_count_excludes_hits_with_no_matching_program(self):
+        # ES returns 3 packages, but only 1 actually provides a binary named `vim`.
+        result = self._search_programs(
+            [
+                self._program_hit(["vim"], "vim"),
+                self._program_hit(["nvim"], "neovim"),
+                self._program_hit(["vimdiff"], "vim-full"),
+            ]
+        )
+        assert result.startswith("Found 1 programs matching 'vim':")
+        assert result.count("* ") == 1
+
+    def test_no_matching_program_reports_nothing_found(self):
+        result = self._search_programs([self._program_hit(["nvim"], "neovim")])
+        assert result == "No programs found matching 'vim'"
+
+    def test_package_count_matches_rendered_entries(self):
+        hits = [
+            {"_source": {"package_pname": "firefox", "package_attr_name": "firefox", "package_pversion": "1"}},
+            {"_source": {"package_pname": "firefox", "package_attr_name": "firefox-esr", "package_pversion": "2"}},
+        ]
+        with (
+            patch("mcp_nixos.sources.nixos.get_channels", return_value={"unstable": "latest-nixos-unstable"}),
+            patch("mcp_nixos.sources.nixos.es_query", Mock(return_value=hits)),
+        ):
+            result = _search_nixos("firefox", "packages", 5, "unstable")
+        assert result.startswith("Found 2 packages matching 'firefox':")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -371,9 +371,10 @@ class TestDottedPackageNameSearch:
         call_args = mock_es.call_args
         query = call_args[0][1]
         query_str = json.dumps(query)
-        # multi_match.query carries the full dotted string; package_pname is one
-        # of the weighted fields inside the same multi_match.
-        assert "python314Packages.matplotlib" in query_str, (
+        # multi_match.query carries the full dotted string, lower-cased (the
+        # whitespace analyzer does not fold case); package_pname is one of the
+        # weighted fields inside the same multi_match.
+        assert "python314packages.matplotlib" in query_str, (
             "multi_match.query should carry the full dotted name, got: " + query_str
         )
         assert "package_pname" in query_str, "package_pname must remain a searchable field"


### PR DESCRIPTION
## AI Usage Disclosure
*AI-assisted: investigated, written, and tested with Claude Code; peer-reviewed with Codex.*

## Summary

Follow-up to #206. That PR fixed a real recall bug — `musicfree` returned nothing even though `musicfree-desktop` exists — by porting the `dis_max(multi_match + wildcard)` block from the search.nixos.org frontend. But that block is only the `must` clause of the upstream query. The clauses that decide **ordering** live in `should` and in a top-level `rescore`, and they were not ported.

The visible result: searching `firefox` ranked `firefox-esr-153-unwrapped` first and `firefox` third. Since these tools return only the top N to an LLM, ranking is not cosmetic.

Ground truth for everything below is `nixos-search/frontend/src/Search/Query.elm` (`encodeRequestBody`, `searchFields`, `shouldClauses`, `popularityClauses`, `rescoreQuery`).

## Ranking: port the rest of the upstream query

| Upstream clause | Effect |
|---|---|
| `term` on the primary field, boost 100 | an exact name always wins |
| `prefix`, boost 20, `case_insensitive` | prefix matches outrank incidental substring hits |
| `constant_score` phrase over description fields, boost 80 | multi-word queries only |
| `rank_feature` saturation on `package_repology_repos` (pivot 20) and `package_dep_count` (pivot 1000), boost 5 | popularity |
| `rescore` window 100, `1.0 / doc['package_attr_name'].value.length()`, weight 20 | short canonical names win ties — this is specifically what puts `firefox` above `firefox-esr-153-unwrapped` |
| `field.*^(w*0.6)` sub-field variants in the multi_match field list | multi-fields contribute at reduced weight |

The query is now also lower-cased before it reaches ES. The `whitespace` analyzer does **not** fold case, so `MusicFree` previously matched only by accident through the wildcard fallback, and never through `term`/`prefix` on the keyword field.

`rescore` is a top-level search-body key rather than part of `query`, so `es_query` grew an optional `rescore=` parameter. Existing callers are unaffected.

## Three defects in the merged query

**1. Wildcard escaping was applied globally.** `_normalize_query` escaped `*`, `?`, `\` before the string reached *everything* — the `multi_match`, and the user-facing text:

```text
before:  search "firefox*"  →  No packages found matching 'firefox\*'
after:   search "firefox*"  →  * firefox (153.0.3)  …
```

Two bugs in one — backslashes echoed at the user, and `firefox*` (a very plausible LLM-generated query) went from usable on `main` to zero results. Metacharacters are now **stripped** while building clauses rather than escaped; none of `*?\` can occur in an attribute path, option name, or binary name, so `firefox*` simply means `firefox`. The response echoes the query unchanged.

**2. Programs search anchored on the wrong field.** `rg` is provided by `ripgrep`, whose attribute name shares nothing with the query. Wildcarding and boosting `package_attr_name` for a programs search pushed the real providers out of the result window:

```text
main:      search rg type=programs  →  rg (provided by ripgrep)
after #206: search rg type=programs  →  No programs found
```

Programs now anchor on `package_programs` and skip the attr-name-length rescore, which is meaningless for binaries. Verified against the live index for `vim`, `rg`, `top`, `ip`, `make`, `node`, `gcc`, `fd` — rendered results now match or beat `main` in every case.

**3. The result header printed the ES hit count, not what was rendered.** The programs branch drops hits whose program list has no exact match, so:

```text
before:  "Found 20 programs matching 'vim':"  followed by 2 entries
after:   "Found 2 programs matching 'vim':"   followed by 2 entries
```

The count is now taken from rendered entries, and a page where every hit was filtered out reports `No programs found` instead of an empty list under a non-zero count.

## Live A/B against `nixos-unstable`

| query | after #206 | this PR |
|---|---|---|
| `firefox` | `firefox-esr-153-unwrapped` 1st | **`firefox` 1st** |
| `python3` | `python313` 1st | **`python3` 1st** |
| `postgresql` | `zabbix-agent2-plugin-postgresql` 2nd | **`postgresql_18`, `_17`, `_16`** |
| `firefox*` | 0 results | **`firefox` 1st** |
| `rg` (programs) | 0 results | **`rg (provided by ripgrep)`** |
| `musicfree` | `musicfree-desktop` | unchanged |
| `firefox_esr` | `firefox-esr*` | unchanged |
| `kdePackages.qt6ct` | exact hit | unchanged |

## Tests

- **New `tests/test_search_query.py`** — 35 unit tests over the pure query-construction helpers: normalization, metacharacter stripping, hyphen variants, wildcard clause shape, field-weight expansion, each boost clause, per-search-type wiring (which primary field, whether rescore is sent), and the rendered-count logic. #206 added no unit coverage for these; all of its new tests were integration-only and therefore deselected in a normal run.
- **Fixed two assertions that could never fail** in `tests/test_integration.py`: `assert " API error" not in result.lower()` (the needle contains uppercase `API`, so `.lower()` can never contain it), and a programs assertion matching text that the result header itself always contains.
- **Added three integration tests**: exact-match-ranks-first, program-by-indirect-binary-name (`rg` → `ripgrep`), and no-escape-leakage on `firefox*`.
- Updated one `test_tools.py` assertion for the now-lower-cased `multi_match.query`.

```text
pytest -m "not integration"                  402 passed, 3 skipped
pytest -m integration -k "Search or Dotted"   31 passed
ruff check / ruff format --check              clean
mypy mcp_nixos/                               clean (20 files)
```

## Notes

- Upstream's negative-word syntax (`-foo` → `must_not` wildcard) is still not implemented. Out of scope here; worth a separate issue if wanted.
- `flake_name` is still omitted from the field list — it is a template field for the flakes index and is ignored against the NixOS package/option indices.
- CI's `build` job will stay red on this branch until #208 merges; that failure is pre-existing on `main` and unrelated to these changes.