### PR TITLE
fix(channels): stop memoizing the stale channel fallback

### DIFF
--- a/mcp_nixos/caches.py
+++ b/mcp_nixos/caches.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import threading
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -40,30 +41,115 @@ class ChannelCache:
     # the alias, so the highest generation is always the freshest data.
     _ALIAS_RE = re.compile(r"^latest-(\d+)-nixos-(unstable|\d+\.\d+)$")
 
+    # After a failed alias probe, serve the fallback for this long before
+    # spending another round of requests. Without it, an outage makes every
+    # concurrent caller queue behind the lock for its own 10s timeout, since
+    # fallback results are deliberately not memoized.
+    _DISCOVERY_RETRY_COOLDOWN = 30.0
+
+    # An alias observed empty means Hydra is mid-publish. Counts — and the
+    # resolution derived from them — are a snapshot of that window, so they
+    # expire: otherwise the process stays pinned to the older generation (or,
+    # if every alias was empty, to the fallback) until it restarts.
+    _ROLLOVER_RECHECK = 300.0
+
     def __init__(self) -> None:
+        # Alias *names* and their document counts are cached separately: names
+        # are what channel resolution needs, counts are display-only. A partial
+        # `_count` failure must not shrink the set of channels we can resolve.
+        self.alias_names: list[str] | None = None
+        # Aliases whose `_count` came back 200 with zero documents. Hydra
+        # publishes the alias before the index finishes filling, so during a
+        # rollover the newest generation can be live but empty — resolving to it
+        # would fail every search for that channel. Distinct from an alias whose
+        # probe merely failed, which stays a candidate.
+        self.empty_aliases: set[str] = set()
         self.available_channels: dict[str, str] | None = None
         self.resolved_channels: dict[str, str] | None = None
         self.using_fallback: bool = False
+        self._failed_at: float | None = None
+        self._rollover_at: float | None = None
+        # Every tool call reaches this cache through `asyncio.to_thread`, so
+        # concurrent first requests can race. The lock keeps each population
+        # decision atomic; the fallback verdict is threaded through return
+        # values rather than shared state so one resolution cannot act on
+        # another's outcome.
+        self._lock = threading.Lock()
 
     def get_available(self) -> dict[str, str]:
-        if self.available_channels is None:
-            self.available_channels = self._discover_available_channels()
-        return self.available_channels if self.available_channels is not None else {}
+        with self._lock:
+            self._expire_rollover_locked()
+            return self._available_locked()
+
+    def _expire_rollover_locked(self) -> None:
+        """Drop discovery state captured while a rollover was in progress."""
+        if self._rollover_at is None or (time.monotonic() - self._rollover_at) < self._ROLLOVER_RECHECK:
+            return
+        self._rollover_at = None
+        self.alias_names = None
+        self.available_channels = None
+        self.resolved_channels = None
+        self.empty_aliases = set()
+
+    def _aliases_locked(self) -> list[str]:
+        """Live alias names, cached once a probe succeeds.
+
+        A failed probe is not cached — the hardcoded fallback goes stale, so the
+        next call must retry — but it does start a cooldown so an outage does
+        not make every caller pay for its own round of requests.
+        """
+        if self.alias_names is not None:
+            return self.alias_names
+        if self._failed_at is not None and (time.monotonic() - self._failed_at) < self._DISCOVERY_RETRY_COOLDOWN:
+            return []
+        aliases = self._list_aliases()
+        if aliases:
+            self.alias_names = aliases
+            self._failed_at = None
+        else:
+            self._failed_at = time.monotonic()
+        return aliases
+
+    def _available_locked(self) -> dict[str, str]:
+        if self.available_channels is not None:
+            return self.available_channels
+        counted, empty, complete = self._discover_available_channels()
+        self.empty_aliases = empty
+        # Start (or clear) the rollover clock so this snapshot cannot outlive
+        # the publish window it was taken in.
+        self._rollover_at = time.monotonic() if empty else None
+        # Cache only a complete listing. A partial one means some `_count`
+        # probes failed transiently, and memoizing it would report those
+        # channels as Unavailable for the life of the process.
+        if complete:
+            self.available_channels = counted
+        return counted
 
     def get_resolved(self) -> dict[str, str]:
-        if self.resolved_channels is None:
-            self.resolved_channels = self._resolve_channels()
-        return self.resolved_channels if self.resolved_channels is not None else {}
+        with self._lock:
+            self._expire_rollover_locked()
+            if self.resolved_channels is not None:
+                return self.resolved_channels
+            resolved, used_fallback, cacheable = self._resolve_channels()
+            self.using_fallback = used_fallback
+            if used_fallback or not cacheable:
+                # Never memoize a fallback: the hardcoded generations go stale
+                # and a retired alias 404s on every query, so caching one
+                # transient discovery failure would poison the whole process.
+                # `cacheable` is False when a `_count` probe failed, which means
+                # a selected alias might turn out to be an empty rollover index.
+                return resolved
+            self.resolved_channels = resolved
+            return resolved
 
-    def _discover_available_channels(self) -> dict[str, str]:
-        """Discover live `latest-*-nixos-*` aliases via Elasticsearch.
+    def _list_aliases(self) -> list[str]:
+        """Return live `latest-<gen>-nixos-<channel>` alias names, newest first.
 
         Replaces a hardcoded `[43..46]` probe loop with a single
         `_cat/aliases` call, so newly published channel generations
         (e.g. `latest-48-nixos-unstable` after Hydra rolls forward) are
         picked up automatically instead of bit-rotting in the source.
         """
-        available: dict[str, str] = {}
         try:
             resp = requests.get(
                 f"{NIXOS_API}/_cat/aliases?format=json",
@@ -71,19 +157,34 @@ class ChannelCache:
                 timeout=10,
             )
             if resp.status_code != 200:
-                return available
+                return []
             entries = resp.json()
             if not isinstance(entries, list):
-                return available
+                return []
         except Exception:
-            return available
+            return []
 
-        aliases = [
+        return [
             entry["alias"]
             for entry in entries
             if isinstance(entry, dict) and self._ALIAS_RE.match(str(entry.get("alias", "")))
         ]
 
+    def _discover_available_channels(self) -> tuple[dict[str, str], set[str], bool]:
+        """Map each live alias to its document count.
+
+        Returns `(counts, empty, complete)`:
+        - `counts` — aliases that hold documents, with a formatted count.
+        - `empty` — aliases confirmed to hold zero documents. Resolution must
+          skip these; an alias whose probe *failed* is absent from both sets and
+          stays a candidate.
+        - `complete` — False when any probe failed, so the caller knows `counts`
+          is not cacheable.
+        """
+        available: dict[str, str] = {}
+        empty: set[str] = set()
+        aliases = self._aliases_locked()
+        complete = bool(aliases)
         for alias in aliases:
             try:
                 count_resp = requests.post(
@@ -96,15 +197,43 @@ class ChannelCache:
                     count = count_resp.json().get("count", 0)
                     if count > 0:
                         available[alias] = f"{count:,} documents"
+                    else:
+                        empty.add(alias)
+                else:
+                    complete = False
             except Exception:
+                complete = False
                 continue
-        return available
+        return available, empty, complete
 
-    def _resolve_channels(self) -> dict[str, str]:
-        available = self.get_available()
+    def _resolve_channels(self) -> tuple[dict[str, str], bool, bool]:
+        """Resolve channel names to aliases.
+
+        Returns `(mapping, used_fallback, cacheable)`. The verdicts are returned
+        rather than stored so a concurrent resolution cannot flip them out from
+        under this one.
+        """
+        # Resolution reads alias *names*, not the counted listing: a cluster that
+        # serves `_cat/aliases` while refusing `_count` still tells us exactly
+        # which channels are live, and a partial count failure must not silently
+        # drop a channel like `stable` from the mapping.
+        aliases = self._aliases_locked()
+        if not aliases:
+            return FALLBACK_CHANNELS.copy(), True, False
+
+        # Probe counts so confirmed-empty aliases can be skipped. Hydra publishes
+        # an alias before its index has filled, so mid-rollover the highest
+        # generation may exist with zero documents — resolving to it would fail
+        # every search for that channel until the process restarts.
+        self._available_locked()
+        # `available_channels` is only populated from a complete probe, so this
+        # doubles as "every alias has a known document count". When some probe
+        # failed, the winning alias might be an empty rollover index we could not
+        # rule out, so the result must not be memoized.
+        cacheable = self.available_channels is not None
+        available = [alias for alias in aliases if alias not in self.empty_aliases]
         if not available:
-            self.using_fallback = True
-            return FALLBACK_CHANNELS.copy()
+            return FALLBACK_CHANNELS.copy(), True, False
 
         # Bucket aliases by channel name ("unstable", "25.11", ...) and
         # remember each candidate's generation so we can pick the maximum
@@ -141,9 +270,8 @@ class ChannelCache:
             resolved["beta"] = resolved["stable"]
 
         if not resolved:
-            self.using_fallback = True
-            return FALLBACK_CHANNELS.copy()
-        return resolved
+            return FALLBACK_CHANNELS.copy(), True, False
+        return resolved, False, cacheable
 
 
 channel_cache = ChannelCache()

--- a/mcp_nixos/config.py
+++ b/mcp_nixos/config.py
@@ -23,12 +23,17 @@ BASE_CHANNELS = {
 }
 
 # Fallback channels when API discovery fails (static mappings based on recent patterns)
+# Last-resort channel map, used only when alias discovery fails outright.
+# These generations bit-rot: Hydra retires old `latest-<gen>-nixos-*` aliases,
+# and a retired alias 404s on every query. The cache therefore never memoizes a
+# fallback result — it retries discovery on the next call (see ChannelCache) —
+# so this map only has to cover a single request during an upstream blip.
 FALLBACK_CHANNELS = {
-    "unstable": "latest-44-nixos-unstable",
-    "stable": "latest-44-nixos-25.11",
-    "25.05": "latest-44-nixos-25.05",
-    "25.11": "latest-44-nixos-25.11",
-    "beta": "latest-44-nixos-25.11",
+    "unstable": "latest-50-nixos-unstable",
+    "stable": "latest-50-nixos-26.05",
+    "26.05": "latest-50-nixos-26.05",
+    "25.11": "latest-48-nixos-25.11",
+    "beta": "latest-50-nixos-26.05",
 }
 
 # Home Manager's option docs are split across mdBook pages. The print view keeps

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,11 @@
 """Tests for server helper functions and internal logic."""
 
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 import requests
+from mcp_nixos.config import FALLBACK_CHANNELS
 from mcp_nixos.server import (
     HOME_MANAGER_URL,
     NIXOS_API,
@@ -245,13 +247,254 @@ class TestChannelCache:
         result = cache.get_available()
         assert result == {"test": "value"}
 
-    def test_resolved_channels_fallback(self):
+    @patch("mcp_nixos.caches.requests.get")
+    def test_resolved_channels_fallback(self, mock_get):
+        mock_get.side_effect = Exception("backend unreachable")
         cache = ChannelCache()
         cache.available_channels = {}  # Empty available channels
         cache.resolved_channels = None
         result = cache.get_resolved()
         assert cache.using_fallback is True
         assert "unstable" in result
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_fallback_is_not_memoized(self, mock_get):
+        """A transient discovery failure must not poison the process.
+
+        The fallback generations go stale — Hydra retires old aliases, and a
+        retired alias 404s on every query. Caching one failed probe would make
+        every later request fail too, and no amount of retrying would recover.
+        """
+        mock_get.side_effect = Exception("backend unreachable")
+        cache = ChannelCache()
+        assert cache.get_resolved() == FALLBACK_CHANNELS
+        assert cache.using_fallback is True
+        # Nothing cached, so the next call re-probes instead of reusing the fallback.
+        assert cache.resolved_channels is None
+        assert cache.available_channels is None
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_recovers_after_a_transient_failure(self, mock_get, mock_post):
+        """Once the backend answers again, resolution must use live aliases."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [{"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"}]
+        mock_get.side_effect = [Exception("backend unreachable"), aliases_resp]
+
+        count_resp = Mock()
+        count_resp.status_code = 200
+        count_resp.json.return_value = {"count": 100000}
+        mock_post.return_value = count_resp
+
+        cache = ChannelCache()
+        assert cache.get_resolved() == FALLBACK_CHANNELS
+        cache._failed_at = None  # skip the retry cooldown
+        assert cache.get_resolved() == {"unstable": "latest-48-nixos-unstable"}
+        assert cache.using_fallback is False
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_resolves_when_count_probes_fail(self, mock_get, mock_post):
+        """Resolution needs alias names only — failing `_count` must not force the fallback."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"},
+            {"alias": "latest-48-nixos-25.11", "index": "nixos-48-25.11-cafebabe"},
+        ]
+        mock_get.return_value = aliases_resp
+        mock_post.side_effect = Exception("count refused")
+
+        cache = ChannelCache()
+        resolved = cache.get_resolved()
+        assert cache.using_fallback is False
+        assert resolved["unstable"] == "latest-48-nixos-unstable"
+        assert resolved["stable"] == "latest-48-nixos-25.11"
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_failed_counts_are_not_memoized(self, mock_get, mock_post):
+        """An empty count map while aliases exist means the probes failed, not that
+        the channels are gone — memoizing it would report every channel as
+        Unavailable for the life of the process."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [{"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"}]
+        mock_get.return_value = aliases_resp
+
+        count_resp = Mock()
+        count_resp.status_code = 200
+        count_resp.json.return_value = {"count": 100000}
+        mock_post.side_effect = [Exception("count refused"), count_resp]
+
+        cache = ChannelCache()
+        assert cache.get_available() == {}
+        assert cache.available_channels is None, "a failed count probe must not be cached"
+        assert cache.get_available() == {"latest-48-nixos-unstable": "100,000 documents"}
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_failed_discovery_backs_off_before_retrying(self, mock_get):
+        """Fallback results are not cached, so without a cooldown every caller
+        would pay for its own round of 10s requests during an outage."""
+        mock_get.side_effect = Exception("backend unreachable")
+        cache = ChannelCache()
+
+        assert cache.get_resolved() == FALLBACK_CHANNELS
+        assert mock_get.call_count == 1
+        # Still inside the cooldown: serve the fallback without re-probing.
+        assert cache.get_resolved() == FALLBACK_CHANNELS
+        assert mock_get.call_count == 1
+
+        cache._failed_at = time.monotonic() - ChannelCache._DISCOVERY_RETRY_COOLDOWN - 1
+        assert cache.get_resolved() == FALLBACK_CHANNELS
+        assert mock_get.call_count == 2, "cooldown expiry must allow another probe"
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_confirmed_empty_alias_is_never_resolved(self, mock_get, mock_post):
+        """Hydra publishes an alias before its index fills, so mid-rollover the
+        highest generation can be live but empty. Resolving to it would fail
+        every search for that channel for the life of the process."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-50-nixos-unstable", "index": "nixos-50-unstable-deadbeef"},
+            {"alias": "latest-51-nixos-unstable", "index": "nixos-51-unstable-fresh"},
+        ]
+        mock_get.return_value = aliases_resp
+
+        def fake_post(url, **_kwargs):
+            resp = Mock()
+            resp.status_code = 200
+            resp.json.return_value = {"count": 0 if "latest-51" in url else 450000}
+            return resp
+
+        mock_post.side_effect = fake_post
+
+        cache = ChannelCache()
+        assert cache.get_resolved()["unstable"] == "latest-50-nixos-unstable"
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_rollover_state_expires_so_the_new_generation_is_picked_up(self, mock_get, mock_post):
+        """A snapshot taken mid-publish must not outlive the publish window, or a
+        long-running server stays pinned to the old generation forever."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-50-nixos-unstable", "index": "nixos-50-unstable-deadbeef"},
+            {"alias": "latest-51-nixos-unstable", "index": "nixos-51-unstable-fresh"},
+        ]
+        mock_get.return_value = aliases_resp
+        filled = {"yet": False}
+
+        def fake_post(url, **_kwargs):
+            resp = Mock()
+            resp.status_code = 200
+            if "latest-51" in url:
+                resp.json.return_value = {"count": 450000 if filled["yet"] else 0}
+            else:
+                resp.json.return_value = {"count": 440000}
+            return resp
+
+        mock_post.side_effect = fake_post
+
+        cache = ChannelCache()
+        assert cache.get_resolved()["unstable"] == "latest-50-nixos-unstable"
+        assert cache.get_resolved()["unstable"] == "latest-50-nixos-unstable"
+
+        filled["yet"] = True
+        cache._rollover_at = time.monotonic() - ChannelCache._ROLLOVER_RECHECK - 1
+        assert cache.get_resolved()["unstable"] == "latest-51-nixos-unstable"
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_resolution_after_a_failed_count_is_not_cached(self, mock_get, mock_post):
+        """A failed probe leaves the alias a candidate, so the winner might be an
+        empty rollover index we could not rule out. Memoizing that would break
+        the channel until restart, so the resolution is recomputed next call."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-50-nixos-unstable", "index": "nixos-50-unstable-deadbeef"},
+            {"alias": "latest-51-nixos-unstable", "index": "nixos-51-unstable-fresh"},
+        ]
+        mock_get.return_value = aliases_resp
+
+        def probe(url, fresh_count):
+            resp = Mock()
+            resp.status_code = 200
+            resp.json.return_value = {"count": fresh_count if "latest-51" in url else 450000}
+            return resp
+
+        # First pass: the new alias's probe fails, so it stays a candidate and wins.
+        # Second pass: the probe succeeds and confirms it is empty.
+        state = {"first": True}
+
+        def fake_post(url, **_kwargs):
+            if "latest-51" in url and state["first"]:
+                state["first"] = False
+                raise requests.RequestException("count refused")
+            return probe(url, 0)
+
+        mock_post.side_effect = fake_post
+
+        cache = ChannelCache()
+        assert cache.get_resolved()["unstable"] == "latest-51-nixos-unstable"
+        assert cache.resolved_channels is None, "an incomplete probe must not be memoized"
+        assert cache.get_resolved()["unstable"] == "latest-50-nixos-unstable"
+
+    @patch("mcp_nixos.caches.requests.post")
+    @patch("mcp_nixos.caches.requests.get")
+    def test_partial_count_failure_keeps_every_channel_resolvable(self, mock_get, mock_post):
+        """Regression: caching the successfully-counted subset dropped channels
+        whose probe failed — `stable` could vanish until process restart."""
+        aliases_resp = Mock()
+        aliases_resp.status_code = 200
+        aliases_resp.json.return_value = [
+            {"alias": "latest-48-nixos-unstable", "index": "nixos-48-unstable-deadbeef"},
+            {"alias": "latest-48-nixos-25.11", "index": "nixos-48-25.11-cafebabe"},
+        ]
+        mock_get.return_value = aliases_resp
+
+        count_resp = Mock()
+        count_resp.status_code = 200
+        count_resp.json.return_value = {"count": 100000}
+
+        def fake_post(url, **_kwargs):
+            if "25.11" in url:
+                raise requests.RequestException("count refused")
+            return count_resp
+
+        mock_post.side_effect = fake_post
+
+        cache = ChannelCache()
+        assert cache.get_available() == {"latest-48-nixos-unstable": "100,000 documents"}
+        assert cache.available_channels is None, "a partial listing must not be cached"
+        # Resolution reads alias names, so the un-counted channel still resolves.
+        resolved = cache.get_resolved()
+        assert resolved["stable"] == "latest-48-nixos-25.11"
+        assert resolved["unstable"] == "latest-48-nixos-unstable"
+
+    @patch("mcp_nixos.caches.requests.get")
+    def test_concurrent_resolution_never_caches_a_fallback(self, mock_get):
+        """Regression: `using_fallback` used to be shared mutable state, so a
+        concurrent success could clear the flag before a fallback resolution
+        checked it — permanently caching the stale map."""
+        import threading
+
+        mock_get.side_effect = Exception("backend unreachable")
+        cache = ChannelCache()
+        results: list[dict[str, str]] = []
+        threads = [threading.Thread(target=lambda: results.append(cache.get_resolved())) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert all(r == FALLBACK_CHANNELS for r in results)
+        assert cache.resolved_channels is None, "a fallback must never end up cached"
 
     @patch("mcp_nixos.caches.requests.post")
     @patch("mcp_nixos.caches.requests.get")
@@ -327,12 +570,13 @@ class TestChannelCache:
         freshest data lives on the highest generation, so the resolver must
         prefer that even when older generations are still live."""
         cache = ChannelCache()
-        cache.available_channels = {
-            "latest-45-nixos-unstable": "400,000 documents",
-            "latest-46-nixos-unstable": "410,000 documents",
-            "latest-48-nixos-unstable": "450,000 documents",
-            "latest-47-nixos-unstable": "440,000 documents",
-        }
+        cache.alias_names = [
+            "latest-45-nixos-unstable",
+            "latest-46-nixos-unstable",
+            "latest-48-nixos-unstable",
+            "latest-47-nixos-unstable",
+        ]
+        cache.available_channels = dict.fromkeys(cache.alias_names, "400,000 documents")
         resolved = cache.get_resolved()
         assert resolved["unstable"] == "latest-48-nixos-unstable"
 
@@ -340,11 +584,12 @@ class TestChannelCache:
         """Same logic for release channels: when multiple generations of the
         same release version are live during a rollover window, pick the max."""
         cache = ChannelCache()
-        cache.available_channels = {
-            "latest-46-nixos-25.11": "400,000 documents",
-            "latest-48-nixos-25.11": "414,000 documents",
-            "latest-47-nixos-25.11": "414,000 documents",
-        }
+        cache.alias_names = [
+            "latest-46-nixos-25.11",
+            "latest-48-nixos-25.11",
+            "latest-47-nixos-25.11",
+        ]
+        cache.available_channels = dict.fromkeys(cache.alias_names, "400,000 documents")
         resolved = cache.get_resolved()
         assert resolved["25.11"] == "latest-48-nixos-25.11"
         assert resolved["stable"] == "latest-48-nixos-25.11"
@@ -354,11 +599,12 @@ class TestChannelCache:
         """`stable` aliases to the newest release version (not the newest
         generation across versions)."""
         cache = ChannelCache()
-        cache.available_channels = {
-            "latest-48-nixos-25.05": "350,000 documents",
-            "latest-48-nixos-25.11": "410,000 documents",
-            "latest-48-nixos-26.05": "420,000 documents",
-        }
+        cache.alias_names = [
+            "latest-48-nixos-25.05",
+            "latest-48-nixos-25.11",
+            "latest-48-nixos-26.05",
+        ]
+        cache.available_channels = dict.fromkeys(cache.alias_names, "400,000 documents")
         resolved = cache.get_resolved()
         assert resolved["stable"] == "latest-48-nixos-26.05"
         assert resolved["beta"] == "latest-48-nixos-26.05"
@@ -370,9 +616,8 @@ class TestChannelCache:
         """Only unstable is live — resolver must still produce a usable map
         and must not synthesize a fake `stable` / `beta` entry."""
         cache = ChannelCache()
-        cache.available_channels = {
-            "latest-48-nixos-unstable": "450,000 documents",
-        }
+        cache.alias_names = ["latest-48-nixos-unstable"]
+        cache.available_channels = {"latest-48-nixos-unstable": "450,000 documents"}
         resolved = cache.get_resolved()
         assert resolved == {"unstable": "latest-48-nixos-unstable"}
 


### PR DESCRIPTION
## AI Usage Disclosure
*AI-assisted: investigated, written, and tested with Claude Code; peer-reviewed with Codex (six rounds).*

## Summary

CI on the release PR (#207) failed with every NixOS query returning:

```
API error: 404 Client Error: Not Found for url:
https://search.nixos.org/backend/latest-44-nixos-unstable/_search
```

`latest-44-nixos-*` is `FALLBACK_CHANNELS`. Hydra retires old `latest-<gen>-nixos-*` aliases as it rolls forward — generation 44 no longer exists (live aliases currently start at 45, up to 50), so **once the fallback is used, every query 404s**.

The trigger is a transient discovery failure. The damage is that the fallback was **memoized**: one failed probe at process start poisoned `resolved_channels` for the life of the process. That is why `@pytest.mark.flaky(reruns=3)` could not recover — every rerun shared the same poisoned cache — and why a long-running MCP server that starts during an upstream blip would serve 404s indefinitely.

Unrelated to #206/#209; reproduced on the release branch, which contains neither.

## What changed

Discovery was conflating states that need different handling. It now separates them:

| Situation | Before | After |
|---|---|---|
| Alias probe failed | fallback, cached forever | fallback, **not** cached; 30s cooldown before re-probing |
| `_cat/aliases` ok, all `_count` failed | fallback | resolves from alias names |
| `_count` failed for *some* aliases | partial map cached; affected channels lost until restart | partial map not cached; every alias stays resolvable |
| Alias confirmed empty (count 0) | excluded | excluded (preserved) |
| Alias empty *and* its probe failed | n/a | stays a candidate, but the resolution is not memoized |
| Rollover finished, new index filled | pinned to old generation until restart | re-probed after 5 minutes |
| Concurrent first requests | `using_fallback` raced; a stale map could be cached | each resolution returns its own verdict under a lock |

Concretely:

- **Alias names and counts are cached separately.** Resolution needs names; counts are display-only for the `channels` action.
- **Three-state count handling**: `count > 0` usable, `count == 0` confirmed-empty and excluded, probe-failed still a candidate.
- **`_ROLLOVER_RECHECK = 300s`** — Hydra publishes an alias before its index fills, so any state captured while an alias was empty is a snapshot of that publish window and expires. A clean probe clears the clock, so steady state is unaffected.
- **`_DISCOVERY_RETRY_COOLDOWN = 30s`** — since fallbacks are deliberately not cached, without this every concurrent caller would queue on the lock for its own 10s timeout during an outage.
- **`FALLBACK_CHANNELS` refreshed** to live aliases; retired 25.05 replaced with 26.05. It remains a last resort covering a single request during a blip — the point of the change above is that it is no longer a permanent state.

## Tests

12 new unit tests in `tests/test_server.py::TestChannelCache`, one per failure mode above — including an 8-thread concurrency regression test and both rollover cases. Four existing resolve tests were reseeded onto `alias_names` + a complete count listing; they were previously making live HTTP requests on every run (unit suite is back to ~4.5s from ~15s).

```text
pytest -m "not integration"   412 passed, 3 skipped
pytest -m integration          78 passed
ruff check / format --check    clean
mypy mcp_nixos/                clean (20 files)
```

Live resolution after the change:

```text
{'unstable': 'latest-50-nixos-unstable', '26.05': 'latest-50-nixos-26.05',
 '25.11': 'latest-48-nixos-25.11', 'stable': 'latest-50-nixos-26.05',
 'beta': 'latest-50-nixos-26.05'}
using_fallback: False
```

## Notes

- Codex reviewed this six times; rounds 2-5 each found a real defect in the preceding fix (shared-state race, partial-count truncation, empty-alias selection, and caching a resolution built on an incomplete probe). Round 6 returned no findings. Each fix has a named regression test.
- The 300s and 30s constants are class attributes on `ChannelCache` so they can be overridden in tests without patching the clock.